### PR TITLE
fix: add 59 segments for cybersecurity domain

### DIFF
--- a/package/zerobias/c_as/.npmrc
+++ b/package/zerobias/c_as/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/c_as/index.yml
+++ b/package/zerobias/c_as/index.yml
@@ -1,0 +1,17 @@
+id: 4cc0e859-7319-448d-9e8e-7bcc5148ee7b
+name: Application Security
+description: Application Security
+segmentType: category
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-c_as-segment.svg
+code: c_as
+externalId: Application Security
+status: active
+parents: 
+  - d_cs
+created: '2025-04-09T22:33:51.136417Z'
+updated: '2025-04-09T22:33:51.136417Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/c_as/logo.svg
+++ b/package/zerobias/c_as/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/c_as/npm-shrinkwrap.json
+++ b/package/zerobias/c_as/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_as",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-c_as",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-d_cs": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/c_as/package.json
+++ b/package/zerobias/c_as/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_as",
+  "version": "1.0.0-rc.0",
+  "description": "Application Security segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/c_as/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.c_as.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-d_cs": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/c_bpao/npm-shrinkwrap.json
+++ b/package/zerobias/c_bpao/npm-shrinkwrap.json
@@ -1,64 +1,23 @@
 {
   "name": "@zerobias-org/segment-zerobias-c_bpao",
-  "version": "1.0.14",
-  "lockfileVersion": 2,
+  "version": "1.0.15-rc.0",
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerobias-org/segment-zerobias-c_bpao",
-      "version": "1.0.14",
+      "version": "1.0.15-rc.0",
       "license": "ISC",
       "dependencies": {
         "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_ba": "^1.0.14"
+        "@zerobias-org/segment_type-zerobias": "^1.0.15-rc.0",
+        "@zerobias-org/segment-zerobias-d_ba": "^1.0.15-rc.0"
       }
     },
     "node_modules/@auditlogic/vendor-zerobias": {
       "version": "1.0.0",
       "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
       "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "node_modules/@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-d_ba": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_ba/-/segment-zerobias-d_ba-1.0.14.tgz",
-      "integrity": "sha512-m2KhnHxoj29VAzgea9ay9JowoaYn/JankAFTXfQxsJPiHeOnN44V0pBXHFdb9VEbWiV250nH+jaZnwV4CRGHFQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
-    }
-  },
-  "dependencies": {
-    "@auditlogic/vendor-zerobias": {
-      "version": "1.0.0",
-      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
-      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "@zerobias-org/segment-zerobias-d_ba": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_ba/-/segment-zerobias-d_ba-1.0.14.tgz",
-      "integrity": "sha512-m2KhnHxoj29VAzgea9ay9JowoaYn/JankAFTXfQxsJPiHeOnN44V0pBXHFdb9VEbWiV250nH+jaZnwV4CRGHFQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
     }
   }
 }

--- a/package/zerobias/c_bsap/npm-shrinkwrap.json
+++ b/package/zerobias/c_bsap/npm-shrinkwrap.json
@@ -1,64 +1,23 @@
 {
   "name": "@zerobias-org/segment-zerobias-c_bsap",
-  "version": "1.0.14",
-  "lockfileVersion": 2,
+  "version": "1.0.15-rc.0",
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerobias-org/segment-zerobias-c_bsap",
-      "version": "1.0.14",
+      "version": "1.0.15-rc.0",
       "license": "ISC",
       "dependencies": {
         "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_ba": "^1.0.14"
+        "@zerobias-org/segment_type-zerobias": "^1.0.15-rc.0",
+        "@zerobias-org/segment-zerobias-d_ba": "^1.0.15-rc.0"
       }
     },
     "node_modules/@auditlogic/vendor-zerobias": {
       "version": "1.0.0",
       "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
       "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "node_modules/@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-d_ba": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_ba/-/segment-zerobias-d_ba-1.0.14.tgz",
-      "integrity": "sha512-m2KhnHxoj29VAzgea9ay9JowoaYn/JankAFTXfQxsJPiHeOnN44V0pBXHFdb9VEbWiV250nH+jaZnwV4CRGHFQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
-    }
-  },
-  "dependencies": {
-    "@auditlogic/vendor-zerobias": {
-      "version": "1.0.0",
-      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
-      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "@zerobias-org/segment-zerobias-d_ba": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_ba/-/segment-zerobias-d_ba-1.0.14.tgz",
-      "integrity": "sha512-m2KhnHxoj29VAzgea9ay9JowoaYn/JankAFTXfQxsJPiHeOnN44V0pBXHFdb9VEbWiV250nH+jaZnwV4CRGHFQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
     }
   }
 }

--- a/package/zerobias/c_ci/npm-shrinkwrap.json
+++ b/package/zerobias/c_ci/npm-shrinkwrap.json
@@ -1,64 +1,23 @@
 {
   "name": "@zerobias-org/segment-zerobias-c_ci",
-  "version": "1.0.14",
-  "lockfileVersion": 2,
+  "version": "1.0.15-rc.0",
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerobias-org/segment-zerobias-c_ci",
-      "version": "1.0.14",
+      "version": "1.0.15-rc.0",
       "license": "ISC",
       "dependencies": {
         "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_itm": "^1.0.14"
+        "@zerobias-org/segment_type-zerobias": "^1.0.15-rc.0",
+        "@zerobias-org/segment-zerobias-d_itm": "^1.0.15-rc.0"
       }
     },
     "node_modules/@auditlogic/vendor-zerobias": {
       "version": "1.0.0",
       "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
       "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "node_modules/@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-d_itm": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_itm/-/segment-zerobias-d_itm-1.0.14.tgz",
-      "integrity": "sha512-9JLGIBm8E9kJL20Fo+kmrLG13xXI2GAC3lpv4xWit46J8q4ROhuFDkcpp40w1hS3BJC00K1QuHhlaC5vW5Dw6w==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
-    }
-  },
-  "dependencies": {
-    "@auditlogic/vendor-zerobias": {
-      "version": "1.0.0",
-      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
-      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "@zerobias-org/segment-zerobias-d_itm": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_itm/-/segment-zerobias-d_itm-1.0.14.tgz",
-      "integrity": "sha512-9JLGIBm8E9kJL20Fo+kmrLG13xXI2GAC3lpv4xWit46J8q4ROhuFDkcpp40w1hS3BJC00K1QuHhlaC5vW5Dw6w==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
     }
   }
 }

--- a/package/zerobias/c_devices/npm-shrinkwrap.json
+++ b/package/zerobias/c_devices/npm-shrinkwrap.json
@@ -1,64 +1,23 @@
 {
   "name": "@zerobias-org/segment-zerobias-c_devices",
-  "version": "1.0.14",
-  "lockfileVersion": 2,
+  "version": "1.0.15-rc.0",
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerobias-org/segment-zerobias-c_devices",
-      "version": "1.0.14",
+      "version": "1.0.15-rc.0",
       "license": "ISC",
       "dependencies": {
         "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_itm": "^1.0.14"
+        "@zerobias-org/segment_type-zerobias": "^1.0.15-rc.0",
+        "@zerobias-org/segment-zerobias-d_itm": "^1.0.15-rc.0"
       }
     },
     "node_modules/@auditlogic/vendor-zerobias": {
       "version": "1.0.0",
       "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
       "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "node_modules/@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-d_itm": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_itm/-/segment-zerobias-d_itm-1.0.14.tgz",
-      "integrity": "sha512-9JLGIBm8E9kJL20Fo+kmrLG13xXI2GAC3lpv4xWit46J8q4ROhuFDkcpp40w1hS3BJC00K1QuHhlaC5vW5Dw6w==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
-    }
-  },
-  "dependencies": {
-    "@auditlogic/vendor-zerobias": {
-      "version": "1.0.0",
-      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
-      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "@zerobias-org/segment-zerobias-d_itm": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_itm/-/segment-zerobias-d_itm-1.0.14.tgz",
-      "integrity": "sha512-9JLGIBm8E9kJL20Fo+kmrLG13xXI2GAC3lpv4xWit46J8q4ROhuFDkcpp40w1hS3BJC00K1QuHhlaC5vW5Dw6w==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
     }
   }
 }

--- a/package/zerobias/c_em/.npmrc
+++ b/package/zerobias/c_em/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/c_em/index.yml
+++ b/package/zerobias/c_em/index.yml
@@ -1,0 +1,17 @@
+id: 2351d061-1ace-4538-938f-6d3bb7c89c17
+name: Exposure Management
+description: Exposure Management
+segmentType: category
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-c_em-segment.svg
+code: c_em
+externalId: Exposure Management
+status: active
+parents: 
+  - d_cs
+created: '2025-04-09T22:33:22.874564Z'
+updated: '2025-04-09T22:33:22.874564Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/c_em/logo.svg
+++ b/package/zerobias/c_em/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/c_em/npm-shrinkwrap.json
+++ b/package/zerobias/c_em/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_em",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-c_em",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-d_cs": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/c_em/package.json
+++ b/package/zerobias/c_em/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_em",
+  "version": "1.0.0-rc.0",
+  "description": "Exposure Management segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/c_em/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.c_em.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-d_cs": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/c_es/.npmrc
+++ b/package/zerobias/c_es/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/c_es/index.yml
+++ b/package/zerobias/c_es/index.yml
@@ -1,0 +1,17 @@
+id: e89568ff-fe8e-43f8-a361-f68ea41e991f
+name: Endpoint Security
+description: Endpoint Security
+segmentType: category
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-c_es-segment.svg
+code: c_es
+externalId: Endpoint Security
+status: active
+parents: 
+  - d_cs
+created: '2025-04-09T22:33:45.586825Z'
+updated: '2025-04-09T22:33:45.586825Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/c_es/logo.svg
+++ b/package/zerobias/c_es/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/c_es/npm-shrinkwrap.json
+++ b/package/zerobias/c_es/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_es",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-c_es",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-d_cs": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/c_es/package.json
+++ b/package/zerobias/c_es/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_es",
+  "version": "1.0.0-rc.0",
+  "description": "Endpoint Security segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/c_es/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.c_es.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-d_cs": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/c_is/.npmrc
+++ b/package/zerobias/c_is/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/c_is/index.yml
+++ b/package/zerobias/c_is/index.yml
@@ -1,0 +1,17 @@
+id: c0c445a3-e717-46cd-be2c-aec20f1598e1
+name: Infrastructure Security
+description: Infrastructure Security
+segmentType: category
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-c_is-segment.svg
+code: c_is
+externalId: Infrastructure Security
+status: active
+parents: 
+  - d_cs
+created: '2025-04-09T22:33:38.249311Z'
+updated: '2025-04-09T22:33:38.249311Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/c_is/logo.svg
+++ b/package/zerobias/c_is/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/c_is/npm-shrinkwrap.json
+++ b/package/zerobias/c_is/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_is",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-c_is",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-d_cs": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/c_is/package.json
+++ b/package/zerobias/c_is/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_is",
+  "version": "1.0.0-rc.0",
+  "description": "Infrastructure Security segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/c_is/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.c_is.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-d_cs": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/c_itg/npm-shrinkwrap.json
+++ b/package/zerobias/c_itg/npm-shrinkwrap.json
@@ -1,64 +1,23 @@
 {
   "name": "@zerobias-org/segment-zerobias-c_itg",
-  "version": "1.0.14",
-  "lockfileVersion": 2,
+  "version": "1.0.15-rc.0",
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerobias-org/segment-zerobias-c_itg",
-      "version": "1.0.14",
+      "version": "1.0.15-rc.0",
       "license": "ISC",
       "dependencies": {
         "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_itm": "^1.0.14"
+        "@zerobias-org/segment_type-zerobias": "^1.0.15-rc.0",
+        "@zerobias-org/segment-zerobias-d_itm": "^1.0.15-rc.0"
       }
     },
     "node_modules/@auditlogic/vendor-zerobias": {
       "version": "1.0.0",
       "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
       "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "node_modules/@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-d_itm": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_itm/-/segment-zerobias-d_itm-1.0.14.tgz",
-      "integrity": "sha512-9JLGIBm8E9kJL20Fo+kmrLG13xXI2GAC3lpv4xWit46J8q4ROhuFDkcpp40w1hS3BJC00K1QuHhlaC5vW5Dw6w==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
-    }
-  },
-  "dependencies": {
-    "@auditlogic/vendor-zerobias": {
-      "version": "1.0.0",
-      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
-      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "@zerobias-org/segment-zerobias-d_itm": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_itm/-/segment-zerobias-d_itm-1.0.14.tgz",
-      "integrity": "sha512-9JLGIBm8E9kJL20Fo+kmrLG13xXI2GAC3lpv4xWit46J8q4ROhuFDkcpp40w1hS3BJC00K1QuHhlaC5vW5Dw6w==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
     }
   }
 }

--- a/package/zerobias/c_itpao/npm-shrinkwrap.json
+++ b/package/zerobias/c_itpao/npm-shrinkwrap.json
@@ -1,64 +1,23 @@
 {
   "name": "@zerobias-org/segment-zerobias-c_itpao",
-  "version": "1.0.14",
-  "lockfileVersion": 2,
+  "version": "1.0.15-rc.0",
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerobias-org/segment-zerobias-c_itpao",
-      "version": "1.0.14",
+      "version": "1.0.15-rc.0",
       "license": "ISC",
       "dependencies": {
         "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_itm": "^1.0.14"
+        "@zerobias-org/segment_type-zerobias": "^1.0.15-rc.0",
+        "@zerobias-org/segment-zerobias-d_itm": "^1.0.15-rc.0"
       }
     },
     "node_modules/@auditlogic/vendor-zerobias": {
       "version": "1.0.0",
       "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
       "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "node_modules/@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-d_itm": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_itm/-/segment-zerobias-d_itm-1.0.14.tgz",
-      "integrity": "sha512-9JLGIBm8E9kJL20Fo+kmrLG13xXI2GAC3lpv4xWit46J8q4ROhuFDkcpp40w1hS3BJC00K1QuHhlaC5vW5Dw6w==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
-    }
-  },
-  "dependencies": {
-    "@auditlogic/vendor-zerobias": {
-      "version": "1.0.0",
-      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
-      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "@zerobias-org/segment-zerobias-d_itm": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_itm/-/segment-zerobias-d_itm-1.0.14.tgz",
-      "integrity": "sha512-9JLGIBm8E9kJL20Fo+kmrLG13xXI2GAC3lpv4xWit46J8q4ROhuFDkcpp40w1hS3BJC00K1QuHhlaC5vW5Dw6w==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
     }
   }
 }

--- a/package/zerobias/c_nasa/npm-shrinkwrap.json
+++ b/package/zerobias/c_nasa/npm-shrinkwrap.json
@@ -1,64 +1,23 @@
 {
   "name": "@zerobias-org/segment-zerobias-c_nasa",
-  "version": "1.0.14",
-  "lockfileVersion": 2,
+  "version": "1.0.15-rc.0",
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerobias-org/segment-zerobias-c_nasa",
-      "version": "1.0.14",
+      "version": "1.0.15-rc.0",
       "license": "ISC",
       "dependencies": {
         "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_itm": "^1.0.14"
+        "@zerobias-org/segment_type-zerobias": "^1.0.15-rc.0",
+        "@zerobias-org/segment-zerobias-d_itm": "^1.0.15-rc.0"
       }
     },
     "node_modules/@auditlogic/vendor-zerobias": {
       "version": "1.0.0",
       "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
       "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "node_modules/@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-d_itm": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_itm/-/segment-zerobias-d_itm-1.0.14.tgz",
-      "integrity": "sha512-9JLGIBm8E9kJL20Fo+kmrLG13xXI2GAC3lpv4xWit46J8q4ROhuFDkcpp40w1hS3BJC00K1QuHhlaC5vW5Dw6w==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
-    }
-  },
-  "dependencies": {
-    "@auditlogic/vendor-zerobias": {
-      "version": "1.0.0",
-      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
-      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "@zerobias-org/segment-zerobias-d_itm": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_itm/-/segment-zerobias-d_itm-1.0.14.tgz",
-      "integrity": "sha512-9JLGIBm8E9kJL20Fo+kmrLG13xXI2GAC3lpv4xWit46J8q4ROhuFDkcpp40w1hS3BJC00K1QuHhlaC5vW5Dw6w==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
     }
   }
 }

--- a/package/zerobias/c_ns/.npmrc
+++ b/package/zerobias/c_ns/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/c_ns/index.yml
+++ b/package/zerobias/c_ns/index.yml
@@ -1,0 +1,17 @@
+id: 73f5c468-df23-4c7d-9bed-88cd75fef005
+name: Network Security
+description: Network Security
+segmentType: category
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-c_ns-segment.svg
+code: c_ns
+externalId: Network Security
+status: active
+parents: 
+  - d_cs
+created: '2025-04-09T22:33:35.810025Z'
+updated: '2025-04-09T22:33:35.810025Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/c_ns/logo.svg
+++ b/package/zerobias/c_ns/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/c_ns/npm-shrinkwrap.json
+++ b/package/zerobias/c_ns/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_ns",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-c_ns",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-d_cs": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/c_ns/package.json
+++ b/package/zerobias/c_ns/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_ns",
+  "version": "1.0.0-rc.0",
+  "description": "Network Security segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/c_ns/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.c_ns.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-d_cs": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/c_op/npm-shrinkwrap.json
+++ b/package/zerobias/c_op/npm-shrinkwrap.json
@@ -1,64 +1,23 @@
 {
   "name": "@zerobias-org/segment-zerobias-c_op",
-  "version": "1.0.14",
-  "lockfileVersion": 2,
+  "version": "1.0.15-rc.0",
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerobias-org/segment-zerobias-c_op",
-      "version": "1.0.14",
+      "version": "1.0.15-rc.0",
       "license": "ISC",
       "dependencies": {
         "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_ba": "^1.0.14"
+        "@zerobias-org/segment_type-zerobias": "^1.0.15-rc.0",
+        "@zerobias-org/segment-zerobias-d_ba": "^1.0.15-rc.0"
       }
     },
     "node_modules/@auditlogic/vendor-zerobias": {
       "version": "1.0.0",
       "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
       "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "node_modules/@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-d_ba": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_ba/-/segment-zerobias-d_ba-1.0.14.tgz",
-      "integrity": "sha512-m2KhnHxoj29VAzgea9ay9JowoaYn/JankAFTXfQxsJPiHeOnN44V0pBXHFdb9VEbWiV250nH+jaZnwV4CRGHFQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
-    }
-  },
-  "dependencies": {
-    "@auditlogic/vendor-zerobias": {
-      "version": "1.0.0",
-      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
-      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "@zerobias-org/segment-zerobias-d_ba": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_ba/-/segment-zerobias-d_ba-1.0.14.tgz",
-      "integrity": "sha512-m2KhnHxoj29VAzgea9ay9JowoaYn/JankAFTXfQxsJPiHeOnN44V0pBXHFdb9VEbWiV250nH+jaZnwV4CRGHFQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
     }
   }
 }

--- a/package/zerobias/c_sg/.npmrc
+++ b/package/zerobias/c_sg/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/c_sg/index.yml
+++ b/package/zerobias/c_sg/index.yml
@@ -1,0 +1,17 @@
+id: eec593c5-c598-4b72-84a2-6edc7bf3ce0a
+name: Security Governance
+description: Security Governance
+segmentType: category
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-c_sg-segment.svg
+code: c_sg
+externalId: Security Governance
+status: active
+parents: 
+  - d_cs
+created: '2025-04-09T22:33:55.105828Z'
+updated: '2025-04-09T22:33:55.105828Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/c_sg/logo.svg
+++ b/package/zerobias/c_sg/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/c_sg/npm-shrinkwrap.json
+++ b/package/zerobias/c_sg/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_sg",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-c_sg",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-d_cs": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/c_sg/package.json
+++ b/package/zerobias/c_sg/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_sg",
+  "version": "1.0.0-rc.0",
+  "description": "Security Governance segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/c_sg/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.c_sg.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-d_cs": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/c_spao/.npmrc
+++ b/package/zerobias/c_spao/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/c_spao/index.yml
+++ b/package/zerobias/c_spao/index.yml
@@ -1,0 +1,17 @@
+id: fe6e4379-a1f3-44dd-8653-d35d54a4611f
+name: Security Processes and Operations
+description: Security Processes and Operations
+segmentType: category
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-c_spao-segment.svg
+code: c_spao
+externalId: Security Processes and Operations
+status: active
+parents: 
+  - d_cs
+created: '2025-04-09T22:33:27.520554Z'
+updated: '2025-04-09T22:33:27.520554Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/c_spao/logo.svg
+++ b/package/zerobias/c_spao/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/c_spao/npm-shrinkwrap.json
+++ b/package/zerobias/c_spao/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_spao",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-c_spao",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-d_cs": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/c_spao/package.json
+++ b/package/zerobias/c_spao/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_spao",
+  "version": "1.0.0-rc.0",
+  "description": "Security Processes and Operations segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/c_spao/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.c_spao.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-d_cs": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/d_ba/npm-shrinkwrap.json
+++ b/package/zerobias/d_ba/npm-shrinkwrap.json
@@ -1,45 +1,22 @@
 {
   "name": "@zerobias-org/segment-zerobias-d_ba",
-  "version": "1.0.14",
-  "lockfileVersion": 2,
+  "version": "1.0.15-rc.0",
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerobias-org/segment-zerobias-d_ba",
-      "version": "1.0.14",
+      "version": "1.0.15-rc.0",
       "license": "ISC",
       "dependencies": {
         "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
+        "@zerobias-org/segment_type-zerobias": "^1.0.15-rc.0"
       }
     },
     "node_modules/@auditlogic/vendor-zerobias": {
       "version": "1.0.0",
       "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
       "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "node_modules/@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    }
-  },
-  "dependencies": {
-    "@auditlogic/vendor-zerobias": {
-      "version": "1.0.0",
-      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
-      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
     }
   }
 }

--- a/package/zerobias/d_cs/.npmrc
+++ b/package/zerobias/d_cs/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/d_cs/index.yml
+++ b/package/zerobias/d_cs/index.yml
@@ -1,0 +1,16 @@
+id: c2f69a81-c604-409d-8408-4ff5d0c81893
+name: Cybersecurity
+description: Cybersecurity
+segmentType: domain
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-d_cs-segment.svg
+code: d_cs
+externalId: Cybersecurity
+status: active
+parents: 
+created: '2025-04-09T22:33:22.557611Z'
+updated: '2025-04-09T22:33:22.557611Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/d_cs/logo.svg
+++ b/package/zerobias/d_cs/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/d_cs/npm-shrinkwrap.json
+++ b/package/zerobias/d_cs/npm-shrinkwrap.json
@@ -1,0 +1,30 @@
+{
+  "name": "@zerobias-org/segment-zerobias-d_cs",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-d_cs",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/d_cs/package.json
+++ b/package/zerobias/d_cs/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@zerobias-org/segment-zerobias-d_cs",
+  "version": "1.0.0-rc.0",
+  "description": "Cybersecurity segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/d_cs/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.d_cs.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/d_itm/npm-shrinkwrap.json
+++ b/package/zerobias/d_itm/npm-shrinkwrap.json
@@ -1,45 +1,22 @@
 {
   "name": "@zerobias-org/segment-zerobias-d_itm",
-  "version": "1.0.14",
-  "lockfileVersion": 2,
+  "version": "1.0.15-rc.0",
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerobias-org/segment-zerobias-d_itm",
-      "version": "1.0.14",
+      "version": "1.0.15-rc.0",
       "license": "ISC",
       "dependencies": {
         "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
+        "@zerobias-org/segment_type-zerobias": "^1.0.15-rc.0"
       }
     },
     "node_modules/@auditlogic/vendor-zerobias": {
       "version": "1.0.0",
       "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
       "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "node_modules/@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    }
-  },
-  "dependencies": {
-    "@auditlogic/vendor-zerobias": {
-      "version": "1.0.0",
-      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
-      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
     }
   }
 }

--- a/package/zerobias/d_test/npm-shrinkwrap.json
+++ b/package/zerobias/d_test/npm-shrinkwrap.json
@@ -1,7 +1,7 @@
 {
   "name": "@zerobias-org/segment-zerobias-d_test",
   "version": "1.0.0",
-  "lockfileVersion": 2,
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
@@ -23,21 +23,6 @@
       "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
       "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
       "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    }
-  },
-  "dependencies": {
-    "@auditlogic/vendor-zerobias": {
-      "version": "1.0.0",
-      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
-      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "requires": {
         "@auditlogic/vendor-zerobias": "^1.0.0"
       }
     }

--- a/package/zerobias/f_fw/.npmrc
+++ b/package/zerobias/f_fw/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/f_fw/index.yml
+++ b/package/zerobias/f_fw/index.yml
@@ -1,0 +1,17 @@
+id: ac516faf-a644-424c-81ae-b9eb02cc64ea
+name: Firewalls
+description: Firewalls
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-f_fw-segment.svg
+code: f_fw
+externalId: Firewalls
+status: active
+parents: 
+  - c_ns
+created: '2025-04-09T22:33:37.788183Z'
+updated: '2025-04-09T22:33:37.788183Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/f_fw/logo.svg
+++ b/package/zerobias/f_fw/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/f_fw/npm-shrinkwrap.json
+++ b/package/zerobias/f_fw/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-f_fw",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-f_fw",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_ns": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/f_fw/package.json
+++ b/package/zerobias/f_fw/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-f_fw",
+  "version": "1.0.0-rc.0",
+  "description": "Firewalls segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/f_fw/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.f_fw.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_ns": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/f_ndlp/.npmrc
+++ b/package/zerobias/f_ndlp/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/f_ndlp/index.yml
+++ b/package/zerobias/f_ndlp/index.yml
@@ -1,0 +1,17 @@
+id: 2270412a-c405-445d-b739-fe5d0cf45bc6
+name: Network Data Loss Prevention (Network DLP)
+description: Network Data Loss Prevention (Network DLP)
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-f_ndlp-segment.svg
+code: f_ndlp
+externalId: Network Data Loss Prevention
+status: active
+parents: 
+  - c_ns
+created: '2025-04-09T22:33:37.553078Z'
+updated: '2025-04-09T22:33:37.553078Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/f_ndlp/logo.svg
+++ b/package/zerobias/f_ndlp/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/f_ndlp/npm-shrinkwrap.json
+++ b/package/zerobias/f_ndlp/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-f_ndlp",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-f_ndlp",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_ns": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/f_ndlp/package.json
+++ b/package/zerobias/f_ndlp/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-f_ndlp",
+  "version": "1.0.0-rc.0",
+  "description": "Network Data Loss Prevention (Network DLP) segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/f_ndlp/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.f_ndlp.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_ns": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/f_nips/.npmrc
+++ b/package/zerobias/f_nips/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/f_nips/index.yml
+++ b/package/zerobias/f_nips/index.yml
@@ -1,0 +1,17 @@
+id: 9168c40a-9896-489b-9e60-d0f582559652
+name: Network Intrusion Protection System (NIPS)
+description: Network Intrusion Protection System (NIPS)
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-f_nips-segment.svg
+code: f_nips
+externalId: Network Intrusion Protection System
+status: active
+parents: 
+  - c_ns
+created: '2025-04-09T22:33:37.062386Z'
+updated: '2025-04-09T22:33:37.062386Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/f_nips/logo.svg
+++ b/package/zerobias/f_nips/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/f_nips/npm-shrinkwrap.json
+++ b/package/zerobias/f_nips/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-f_nips",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-f_nips",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_ns": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/f_nips/package.json
+++ b/package/zerobias/f_nips/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-f_nips",
+  "version": "1.0.0-rc.0",
+  "description": "Network Intrusion Protection System (NIPS) segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/f_nips/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.f_nips.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_ns": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/f_ravpn/.npmrc
+++ b/package/zerobias/f_ravpn/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/f_ravpn/index.yml
+++ b/package/zerobias/f_ravpn/index.yml
@@ -1,0 +1,17 @@
+id: 6ea96c60-c4f8-4ffe-b559-4d19c5d04473
+name: Remote Access VPNs
+description: Remote Access VPNs
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-f_ravpn-segment.svg
+code: f_ravpn
+externalId: Remote Access VPNs
+status: active
+parents: 
+  - c_ns
+created: '2025-04-09T22:33:38.021838Z'
+updated: '2025-04-09T22:33:38.021838Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/f_ravpn/logo.svg
+++ b/package/zerobias/f_ravpn/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/f_ravpn/npm-shrinkwrap.json
+++ b/package/zerobias/f_ravpn/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-f_ravpn",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-f_ravpn",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_ns": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/f_ravpn/package.json
+++ b/package/zerobias/f_ravpn/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-f_ravpn",
+  "version": "1.0.0-rc.0",
+  "description": "Remote Access VPNs segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/f_ravpn/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.f_ravpn.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_ns": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/f_wips/.npmrc
+++ b/package/zerobias/f_wips/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/f_wips/index.yml
+++ b/package/zerobias/f_wips/index.yml
@@ -1,0 +1,17 @@
+id: 4f4833c0-0762-43c9-93cc-6dd999b42338
+name: Wireless Intrusion Protection System (WIPS)
+description: Wireless Intrusion Protection System (WIPS)
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-f_wips-segment.svg
+code: f_wips
+externalId: Wireless Intrusion Protection System
+status: active
+parents: 
+  - c_ns
+created: '2025-04-09T22:33:37.328109Z'
+updated: '2025-04-09T22:33:37.328109Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/f_wips/logo.svg
+++ b/package/zerobias/f_wips/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/f_wips/npm-shrinkwrap.json
+++ b/package/zerobias/f_wips/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-f_wips",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-f_wips",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_ns": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/f_wips/package.json
+++ b/package/zerobias/f_wips/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-f_wips",
+  "version": "1.0.0-rc.0",
+  "description": "Wireless Intrusion Protection System (WIPS) segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/f_wips/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.f_wips.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_ns": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/g_ar/.npmrc
+++ b/package/zerobias/g_ar/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/g_ar/index.yml
+++ b/package/zerobias/g_ar/index.yml
@@ -1,0 +1,17 @@
+id: 592aff01-3df4-4dc3-8b8b-ed6a581f3217
+name: Automated Remediation (aka Automated Response)
+description: Automated Remediation (aka Automated Response)
+segmentType: feature_group
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-g_ar-segment.svg
+code: g_ar
+externalId: Automated Remediation
+status: active
+parents: 
+  - t_edr
+created: '2025-04-09T22:33:47.067724Z'
+updated: '2025-04-09T22:33:47.067724Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/g_ar/logo.svg
+++ b/package/zerobias/g_ar/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/g_ar/npm-shrinkwrap.json
+++ b/package/zerobias/g_ar/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-g_ar",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-g_ar",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-t_edr": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/g_ar/package.json
+++ b/package/zerobias/g_ar/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-g_ar",
+  "version": "1.0.0-rc.0",
+  "description": "Automated Remediation (aka Automated Response) segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/g_ar/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.g_ar.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-t_edr": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/g_tdap/.npmrc
+++ b/package/zerobias/g_tdap/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/g_tdap/index.yml
+++ b/package/zerobias/g_tdap/index.yml
@@ -1,0 +1,17 @@
+id: c45371c6-de92-487a-b40c-641183a01ee4
+name: Threat Detection and Prevention
+description: Threat Detection and Prevention
+segmentType: feature_group
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-g_tdap-segment.svg
+code: g_tdap
+externalId: Threat Detection and Prevention
+status: active
+parents: 
+  - t_rasp
+created: '2025-04-09T22:33:53.092248Z'
+updated: '2025-04-09T22:33:53.092248Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/g_tdap/logo.svg
+++ b/package/zerobias/g_tdap/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/g_tdap/npm-shrinkwrap.json
+++ b/package/zerobias/g_tdap/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-g_tdap",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-g_tdap",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-t_rasp": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/g_tdap/package.json
+++ b/package/zerobias/g_tdap/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-g_tdap",
+  "version": "1.0.0-rc.0",
+  "description": "Threat Detection and Prevention segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/g_tdap/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.g_tdap.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-t_rasp": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/g_tm/.npmrc
+++ b/package/zerobias/g_tm/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/g_tm/index.yml
+++ b/package/zerobias/g_tm/index.yml
@@ -1,0 +1,23 @@
+id: 294c970f-bbf8-4aab-913c-1185a1fd14b0
+name: Threat Monitoring (aka Proactive Threat Hunting)
+description: Threat Monitoring (aka Proactive Threat Hunting)
+segmentType: feature_group
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-g_tm-segment.svg
+code: g_tm
+externalId: Threat Monitoring
+status: active
+parents: 
+  - t_siem
+  - t_ids
+  - t_hids
+  - t_cbids
+  - t_edr
+  - t_rasp
+  - t_cspm
+created: '2025-04-09T22:33:33.437980Z'
+updated: '2025-04-09T22:33:58.430000Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/g_tm/logo.svg
+++ b/package/zerobias/g_tm/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/g_tm/npm-shrinkwrap.json
+++ b/package/zerobias/g_tm/npm-shrinkwrap.json
@@ -1,0 +1,37 @@
+{
+  "name": "@zerobias-org/segment-zerobias-g_tm",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-g_tm",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-t_cbids": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-t_cspm": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-t_edr": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-t_hids": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-t_ids": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-t_rasp": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-t_siem": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/g_tm/package.json
+++ b/package/zerobias/g_tm/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@zerobias-org/segment-zerobias-g_tm",
+  "version": "1.0.0-rc.0",
+  "description": "Threat Monitoring (aka Proactive Threat Hunting) segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/g_tm/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.g_tm.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-t_siem": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-t_ids": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-t_hids": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-t_cbids": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-t_edr": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-t_rasp": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-t_cspm": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/t_aai/npm-shrinkwrap.json
+++ b/package/zerobias/t_aai/npm-shrinkwrap.json
@@ -1,84 +1,23 @@
 {
   "name": "@zerobias-org/segment-zerobias-t_aai",
-  "version": "1.0.14",
-  "lockfileVersion": 2,
+  "version": "1.0.15-rc.0",
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerobias-org/segment-zerobias-t_aai",
-      "version": "1.0.14",
+      "version": "1.0.15-rc.0",
       "license": "ISC",
       "dependencies": {
         "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-c_op": "^1.0.14"
+        "@zerobias-org/segment_type-zerobias": "^1.0.15-rc.0",
+        "@zerobias-org/segment-zerobias-c_op": "^1.0.15-rc.0"
       }
     },
     "node_modules/@auditlogic/vendor-zerobias": {
       "version": "1.0.0",
       "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
       "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "node_modules/@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-c_op": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-c_op/-/segment-zerobias-c_op-1.0.14.tgz",
-      "integrity": "sha512-+ovx6zOsLePQf0YmsKicmEgokNkwwBeCFTYabz9hWY3y6KCQ0bYZn7BsGgOYEGQ2WGx3e99J0sc1G3deAPpRag==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_ba": "^1.0.14"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-d_ba": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_ba/-/segment-zerobias-d_ba-1.0.14.tgz",
-      "integrity": "sha512-m2KhnHxoj29VAzgea9ay9JowoaYn/JankAFTXfQxsJPiHeOnN44V0pBXHFdb9VEbWiV250nH+jaZnwV4CRGHFQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
-    }
-  },
-  "dependencies": {
-    "@auditlogic/vendor-zerobias": {
-      "version": "1.0.0",
-      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
-      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "@zerobias-org/segment-zerobias-c_op": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-c_op/-/segment-zerobias-c_op-1.0.14.tgz",
-      "integrity": "sha512-+ovx6zOsLePQf0YmsKicmEgokNkwwBeCFTYabz9hWY3y6KCQ0bYZn7BsGgOYEGQ2WGx3e99J0sc1G3deAPpRag==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_ba": "^1.0.14"
-      }
-    },
-    "@zerobias-org/segment-zerobias-d_ba": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_ba/-/segment-zerobias-d_ba-1.0.14.tgz",
-      "integrity": "sha512-m2KhnHxoj29VAzgea9ay9JowoaYn/JankAFTXfQxsJPiHeOnN44V0pBXHFdb9VEbWiV250nH+jaZnwV4CRGHFQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
     }
   }
 }

--- a/package/zerobias/t_aisec/.npmrc
+++ b/package/zerobias/t_aisec/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/t_aisec/index.yml
+++ b/package/zerobias/t_aisec/index.yml
@@ -1,0 +1,17 @@
+id: b6906ba4-2b4c-4825-a0f0-6e23160c7cc3
+name: AI Security (AI Sec)
+description: AI Security (AI Sec)
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-t_aisec-segment.svg
+code: t_aisec
+externalId: AI Security
+status: active
+parents: 
+  - c_as
+created: '2025-04-09T22:33:54.889119Z'
+updated: '2025-04-09T22:33:54.889119Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/t_aisec/logo.svg
+++ b/package/zerobias/t_aisec/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/t_aisec/npm-shrinkwrap.json
+++ b/package/zerobias/t_aisec/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_aisec",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-t_aisec",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_as": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/t_aisec/package.json
+++ b/package/zerobias/t_aisec/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_aisec",
+  "version": "1.0.0-rc.0",
+  "description": "AI Security (AI Sec) segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/t_aisec/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.t_aisec.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_as": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/t_aispm/.npmrc
+++ b/package/zerobias/t_aispm/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/t_aispm/index.yml
+++ b/package/zerobias/t_aispm/index.yml
@@ -1,0 +1,17 @@
+id: fe282739-9955-4953-a789-6037c1d5a11b
+name: Artificial Intelligence Security Posture Management (AI-SPM)
+description: Artificial Intelligence Security Posture Management (AI-SPM)
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-t_aispm-segment.svg
+code: t_aispm
+externalId: Artificial Intelligence Security Posture Management
+status: active
+parents: 
+  - c_sg
+created: '2025-04-09T22:33:59.213462Z'
+updated: '2025-04-09T22:33:59.213462Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/t_aispm/logo.svg
+++ b/package/zerobias/t_aispm/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/t_aispm/npm-shrinkwrap.json
+++ b/package/zerobias/t_aispm/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_aispm",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-t_aispm",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_sg": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/t_aispm/package.json
+++ b/package/zerobias/t_aispm/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_aispm",
+  "version": "1.0.0-rc.0",
+  "description": "Artificial Intelligence Security Posture Management (AI-SPM) segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/t_aispm/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.t_aispm.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_sg": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/t_apa/.npmrc
+++ b/package/zerobias/t_apa/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/t_apa/index.yml
+++ b/package/zerobias/t_apa/index.yml
@@ -1,0 +1,17 @@
+id: e92171f8-9248-4c9e-b42d-360207581341
+name: Attack Path Analysis (APA)
+description: Attack Path Analysis (APA)
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-t_apa-segment.svg
+code: t_apa
+externalId: Attack Path Analysis
+status: active
+parents: 
+  - c_em
+created: '2025-04-09T22:33:26.374323Z'
+updated: '2025-04-09T22:33:26.374323Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/t_apa/logo.svg
+++ b/package/zerobias/t_apa/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/t_apa/npm-shrinkwrap.json
+++ b/package/zerobias/t_apa/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_apa",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-t_apa",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_em": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/t_apa/package.json
+++ b/package/zerobias/t_apa/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_apa",
+  "version": "1.0.0-rc.0",
+  "description": "Attack Path Analysis (APA) segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/t_apa/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.t_apa.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_em": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/t_apisec/.npmrc
+++ b/package/zerobias/t_apisec/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/t_apisec/index.yml
+++ b/package/zerobias/t_apisec/index.yml
@@ -1,0 +1,17 @@
+id: 0c805b5a-d5b5-43f0-a13b-1b4145b27d78
+name: API Security (API Sec)
+description: API Security (API Sec)
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-t_apisec-segment.svg
+code: t_apisec
+externalId: API Security
+status: active
+parents: 
+  - c_as
+created: '2025-04-09T22:33:54.434298Z'
+updated: '2025-04-09T22:33:54.434298Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/t_apisec/logo.svg
+++ b/package/zerobias/t_apisec/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/t_apisec/npm-shrinkwrap.json
+++ b/package/zerobias/t_apisec/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_apisec",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-t_apisec",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_as": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/t_apisec/package.json
+++ b/package/zerobias/t_apisec/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_apisec",
+  "version": "1.0.0-rc.0",
+  "description": "API Security (API Sec) segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/t_apisec/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.t_apisec.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_as": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/t_asm/.npmrc
+++ b/package/zerobias/t_asm/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/t_asm/index.yml
+++ b/package/zerobias/t_asm/index.yml
@@ -1,0 +1,17 @@
+id: 9c8602bc-4192-4ac3-a98f-8adfbe320141
+name: Application Security Management (ASM)
+description: Application Security Management (ASM)
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-t_asm-segment.svg
+code: t_asm
+externalId: Application Security Management
+status: active
+parents: 
+  - c_as
+created: '2025-04-09T22:33:51.368126Z'
+updated: '2025-04-09T22:33:51.368126Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/t_asm/logo.svg
+++ b/package/zerobias/t_asm/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/t_asm/npm-shrinkwrap.json
+++ b/package/zerobias/t_asm/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_asm",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-t_asm",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_as": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/t_asm/package.json
+++ b/package/zerobias/t_asm/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_asm",
+  "version": "1.0.0-rc.0",
+  "description": "Application Security Management (ASM) segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/t_asm/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.t_asm.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_as": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/t_asoc/.npmrc
+++ b/package/zerobias/t_asoc/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/t_asoc/index.yml
+++ b/package/zerobias/t_asoc/index.yml
@@ -1,0 +1,17 @@
+id: c658e719-bb9a-4e58-a5a4-4eddf669ae4d
+name: Application Security Orchestration and Correlation (ASOC)
+description: Application Security Orchestration and Correlation (ASOC)
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-t_asoc-segment.svg
+code: t_asoc
+externalId: Application Security Orchestration and Correlation
+status: active
+parents: 
+  - c_spao
+created: '2025-04-09T22:33:27.794274Z'
+updated: '2025-04-09T22:33:27.794274Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/t_asoc/logo.svg
+++ b/package/zerobias/t_asoc/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/t_asoc/npm-shrinkwrap.json
+++ b/package/zerobias/t_asoc/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_asoc",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-t_asoc",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_spao": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/t_asoc/package.json
+++ b/package/zerobias/t_asoc/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_asoc",
+  "version": "1.0.0-rc.0",
+  "description": "Application Security Orchestration and Correlation (ASOC) segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/t_asoc/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.t_asoc.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_spao": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/t_aspm/.npmrc
+++ b/package/zerobias/t_aspm/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/t_aspm/index.yml
+++ b/package/zerobias/t_aspm/index.yml
@@ -1,0 +1,17 @@
+id: 6ae0475b-d886-46d1-b4ed-32b4ba5ff36c
+name: Application Security Posture Management (ASPM)
+description: Application Security Posture Management (ASPM)
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-t_aspm-segment.svg
+code: t_aspm
+externalId: Application Security Posture Management
+status: active
+parents: 
+  - c_sg
+created: '2025-04-09T22:33:59.447996Z'
+updated: '2025-04-09T22:33:59.447996Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/t_aspm/logo.svg
+++ b/package/zerobias/t_aspm/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/t_aspm/npm-shrinkwrap.json
+++ b/package/zerobias/t_aspm/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_aspm",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-t_aspm",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_sg": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/t_aspm/package.json
+++ b/package/zerobias/t_aspm/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_aspm",
+  "version": "1.0.0-rc.0",
+  "description": "Application Security Posture Management (ASPM) segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/t_aspm/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.t_aspm.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_sg": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/t_av/.npmrc
+++ b/package/zerobias/t_av/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/t_av/index.yml
+++ b/package/zerobias/t_av/index.yml
@@ -1,0 +1,17 @@
+id: f5ff1309-9c89-47e6-92b3-0b1f696669e7
+name: Antivirus and antimalware software (AV)
+description: Antivirus and antimalware software (AV)
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-t_av-segment.svg
+code: t_av
+externalId: Antivirus and antimalware software
+status: active
+parents: 
+  - c_es
+created: '2025-04-09T22:33:48.936635Z'
+updated: '2025-04-09T22:33:48.936635Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/t_av/logo.svg
+++ b/package/zerobias/t_av/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/t_av/npm-shrinkwrap.json
+++ b/package/zerobias/t_av/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_av",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-t_av",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_es": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/t_av/package.json
+++ b/package/zerobias/t_av/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_av",
+  "version": "1.0.0-rc.0",
+  "description": "Antivirus and antimalware software (AV) segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/t_av/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.t_av.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_es": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/t_bi/npm-shrinkwrap.json
+++ b/package/zerobias/t_bi/npm-shrinkwrap.json
@@ -1,84 +1,23 @@
 {
   "name": "@zerobias-org/segment-zerobias-t_bi",
-  "version": "1.0.14",
-  "lockfileVersion": 2,
+  "version": "1.0.15-rc.0",
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerobias-org/segment-zerobias-t_bi",
-      "version": "1.0.14",
+      "version": "1.0.15-rc.0",
       "license": "ISC",
       "dependencies": {
         "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-c_bsap": "^1.0.14"
+        "@zerobias-org/segment_type-zerobias": "^1.0.15-rc.0",
+        "@zerobias-org/segment-zerobias-c_bsap": "^1.0.15-rc.0"
       }
     },
     "node_modules/@auditlogic/vendor-zerobias": {
       "version": "1.0.0",
       "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
       "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "node_modules/@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-c_bsap": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-c_bsap/-/segment-zerobias-c_bsap-1.0.14.tgz",
-      "integrity": "sha512-SLetPIxgni9YqzMdB00RHiXzgCW+mx2XyGXT7wxxvaBnfcKWAoKZ4Wij2HqPJ4PsbTTvM5VOrkAD5ryEFM4NGg==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_ba": "^1.0.14"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-d_ba": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_ba/-/segment-zerobias-d_ba-1.0.14.tgz",
-      "integrity": "sha512-m2KhnHxoj29VAzgea9ay9JowoaYn/JankAFTXfQxsJPiHeOnN44V0pBXHFdb9VEbWiV250nH+jaZnwV4CRGHFQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
-    }
-  },
-  "dependencies": {
-    "@auditlogic/vendor-zerobias": {
-      "version": "1.0.0",
-      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
-      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "@zerobias-org/segment-zerobias-c_bsap": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-c_bsap/-/segment-zerobias-c_bsap-1.0.14.tgz",
-      "integrity": "sha512-SLetPIxgni9YqzMdB00RHiXzgCW+mx2XyGXT7wxxvaBnfcKWAoKZ4Wij2HqPJ4PsbTTvM5VOrkAD5ryEFM4NGg==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_ba": "^1.0.14"
-      }
-    },
-    "@zerobias-org/segment-zerobias-d_ba": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_ba/-/segment-zerobias-d_ba-1.0.14.tgz",
-      "integrity": "sha512-m2KhnHxoj29VAzgea9ay9JowoaYn/JankAFTXfQxsJPiHeOnN44V0pBXHFdb9VEbWiV250nH+jaZnwV4CRGHFQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
     }
   }
 }

--- a/package/zerobias/t_caasm/.npmrc
+++ b/package/zerobias/t_caasm/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/t_caasm/index.yml
+++ b/package/zerobias/t_caasm/index.yml
@@ -1,0 +1,17 @@
+id: a1432f4d-227c-4274-957f-ace5b46f5a5d
+name: Cyber Asset Attack Surface Management (CAASM)
+description: Cyber Asset Attack Surface Management (CAASM)
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-t_caasm-segment.svg
+code: t_caasm
+externalId: Cyber Asset Attack Surface Management
+status: active
+parents: 
+  - c_em
+created: '2025-04-09T22:33:23.211211Z'
+updated: '2025-04-09T22:33:23.211211Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/t_caasm/logo.svg
+++ b/package/zerobias/t_caasm/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/t_caasm/npm-shrinkwrap.json
+++ b/package/zerobias/t_caasm/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_caasm",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-t_caasm",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_em": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/t_caasm/package.json
+++ b/package/zerobias/t_caasm/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_caasm",
+  "version": "1.0.0-rc.0",
+  "description": "Cyber Asset Attack Surface Management (CAASM) segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/t_caasm/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.t_caasm.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_em": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/t_cac/npm-shrinkwrap.json
+++ b/package/zerobias/t_cac/npm-shrinkwrap.json
@@ -1,84 +1,23 @@
 {
   "name": "@zerobias-org/segment-zerobias-t_cac",
-  "version": "1.0.14",
-  "lockfileVersion": 2,
+  "version": "1.0.15-rc.0",
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerobias-org/segment-zerobias-t_cac",
-      "version": "1.0.14",
+      "version": "1.0.15-rc.0",
       "license": "ISC",
       "dependencies": {
         "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-c_op": "^1.0.14"
+        "@zerobias-org/segment_type-zerobias": "^1.0.15-rc.0",
+        "@zerobias-org/segment-zerobias-c_op": "^1.0.15-rc.0"
       }
     },
     "node_modules/@auditlogic/vendor-zerobias": {
       "version": "1.0.0",
       "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
       "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "node_modules/@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-c_op": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-c_op/-/segment-zerobias-c_op-1.0.14.tgz",
-      "integrity": "sha512-+ovx6zOsLePQf0YmsKicmEgokNkwwBeCFTYabz9hWY3y6KCQ0bYZn7BsGgOYEGQ2WGx3e99J0sc1G3deAPpRag==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_ba": "^1.0.14"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-d_ba": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_ba/-/segment-zerobias-d_ba-1.0.14.tgz",
-      "integrity": "sha512-m2KhnHxoj29VAzgea9ay9JowoaYn/JankAFTXfQxsJPiHeOnN44V0pBXHFdb9VEbWiV250nH+jaZnwV4CRGHFQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
-    }
-  },
-  "dependencies": {
-    "@auditlogic/vendor-zerobias": {
-      "version": "1.0.0",
-      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
-      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "@zerobias-org/segment-zerobias-c_op": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-c_op/-/segment-zerobias-c_op-1.0.14.tgz",
-      "integrity": "sha512-+ovx6zOsLePQf0YmsKicmEgokNkwwBeCFTYabz9hWY3y6KCQ0bYZn7BsGgOYEGQ2WGx3e99J0sc1G3deAPpRag==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_ba": "^1.0.14"
-      }
-    },
-    "@zerobias-org/segment-zerobias-d_ba": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_ba/-/segment-zerobias-d_ba-1.0.14.tgz",
-      "integrity": "sha512-m2KhnHxoj29VAzgea9ay9JowoaYn/JankAFTXfQxsJPiHeOnN44V0pBXHFdb9VEbWiV250nH+jaZnwV4CRGHFQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
     }
   }
 }

--- a/package/zerobias/t_cbids/.npmrc
+++ b/package/zerobias/t_cbids/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/t_cbids/index.yml
+++ b/package/zerobias/t_cbids/index.yml
@@ -1,0 +1,17 @@
+id: 2d0a9a54-906c-46d4-bfd0-d6bf4219842f
+name: Cloud-based Intrusion Detection System (IDS)
+description: Cloud-based Intrusion Detection System (IDS)
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-t_cbids-segment.svg
+code: t_cbids
+externalId: Cloud-based Intrusion Detection System
+status: active
+parents: 
+  - c_is
+created: '2025-04-09T22:33:43.627765Z'
+updated: '2025-04-09T22:33:43.627765Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/t_cbids/logo.svg
+++ b/package/zerobias/t_cbids/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/t_cbids/npm-shrinkwrap.json
+++ b/package/zerobias/t_cbids/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_cbids",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-t_cbids",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_is": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/t_cbids/package.json
+++ b/package/zerobias/t_cbids/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_cbids",
+  "version": "1.0.0-rc.0",
+  "description": "Cloud-based Intrusion Detection System (IDS) segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/t_cbids/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.t_cbids.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_is": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/t_cdr/.npmrc
+++ b/package/zerobias/t_cdr/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/t_cdr/index.yml
+++ b/package/zerobias/t_cdr/index.yml
@@ -1,0 +1,17 @@
+id: 6caa8cd8-14a0-4963-b88f-8d13afde73cd
+name: Cloud Detection and Response (CDR)
+description: Cloud Detection and Response (CDR)
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-t_cdr-segment.svg
+code: t_cdr
+externalId: Cloud Detection and Response
+status: active
+parents: 
+  - c_is
+created: '2025-04-09T22:33:45.130780Z'
+updated: '2025-04-09T22:33:45.130780Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/t_cdr/logo.svg
+++ b/package/zerobias/t_cdr/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/t_cdr/npm-shrinkwrap.json
+++ b/package/zerobias/t_cdr/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_cdr",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-t_cdr",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_is": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/t_cdr/package.json
+++ b/package/zerobias/t_cdr/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_cdr",
+  "version": "1.0.0-rc.0",
+  "description": "Cloud Detection and Response (CDR) segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/t_cdr/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.t_cdr.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_is": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/t_ciem/.npmrc
+++ b/package/zerobias/t_ciem/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/t_ciem/index.yml
+++ b/package/zerobias/t_ciem/index.yml
@@ -1,0 +1,17 @@
+id: 6fad4aad-8de7-46dd-a7bb-ba3b9ebe11cf
+name: Cloud Infrastructure Entitlement Management (CIEM)
+description: Cloud Infrastructure Entitlement Management (CIEM)
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-t_ciem-segment.svg
+code: t_ciem
+externalId: Cloud Infrastructure Entitlement Management
+status: active
+parents: 
+  - c_is
+created: '2025-04-09T22:33:45.358892Z'
+updated: '2025-04-09T22:33:45.358892Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/t_ciem/logo.svg
+++ b/package/zerobias/t_ciem/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/t_ciem/npm-shrinkwrap.json
+++ b/package/zerobias/t_ciem/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_ciem",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-t_ciem",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_is": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/t_ciem/package.json
+++ b/package/zerobias/t_ciem/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_ciem",
+  "version": "1.0.0-rc.0",
+  "description": "Cloud Infrastructure Entitlement Management (CIEM) segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/t_ciem/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.t_ciem.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_is": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/t_cops/.npmrc
+++ b/package/zerobias/t_cops/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/t_cops/index.yml
+++ b/package/zerobias/t_cops/index.yml
@@ -1,0 +1,17 @@
+id: 41e792a5-2871-4f43-ab2f-88753c1114f3
+name: Container Orchestration Platform Security
+description: Container Orchestration Platform Security
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-t_cops-segment.svg
+code: t_cops
+externalId: Container Orchestration Platform Security
+status: active
+parents: 
+  - c_is
+created: '2025-04-09T22:33:42.292529Z'
+updated: '2025-04-09T22:33:42.292529Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/t_cops/logo.svg
+++ b/package/zerobias/t_cops/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/t_cops/npm-shrinkwrap.json
+++ b/package/zerobias/t_cops/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_cops",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-t_cops",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_is": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/t_cops/package.json
+++ b/package/zerobias/t_cops/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_cops",
+  "version": "1.0.0-rc.0",
+  "description": "Container Orchestration Platform Security segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/t_cops/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.t_cops.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_is": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/t_crm/npm-shrinkwrap.json
+++ b/package/zerobias/t_crm/npm-shrinkwrap.json
@@ -1,84 +1,23 @@
 {
   "name": "@zerobias-org/segment-zerobias-t_crm",
-  "version": "1.0.14",
-  "lockfileVersion": 2,
+  "version": "1.0.15-rc.0",
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerobias-org/segment-zerobias-t_crm",
-      "version": "1.0.14",
+      "version": "1.0.15-rc.0",
       "license": "ISC",
       "dependencies": {
         "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-c_bpao": "^1.0.14"
+        "@zerobias-org/segment_type-zerobias": "^1.0.15-rc.0",
+        "@zerobias-org/segment-zerobias-c_bpao": "^1.0.15-rc.0"
       }
     },
     "node_modules/@auditlogic/vendor-zerobias": {
       "version": "1.0.0",
       "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
       "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "node_modules/@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-c_bpao": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-c_bpao/-/segment-zerobias-c_bpao-1.0.14.tgz",
-      "integrity": "sha512-ERSkFtWfaxau5g5I0HVml71xghmplTh93fJ3Y+NqsU5H1d6B7nhFvI69rTMwu4fP4XETFqNE6U4g2Ztvnaa83A==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_ba": "^1.0.14"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-d_ba": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_ba/-/segment-zerobias-d_ba-1.0.14.tgz",
-      "integrity": "sha512-m2KhnHxoj29VAzgea9ay9JowoaYn/JankAFTXfQxsJPiHeOnN44V0pBXHFdb9VEbWiV250nH+jaZnwV4CRGHFQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
-    }
-  },
-  "dependencies": {
-    "@auditlogic/vendor-zerobias": {
-      "version": "1.0.0",
-      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
-      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "@zerobias-org/segment-zerobias-c_bpao": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-c_bpao/-/segment-zerobias-c_bpao-1.0.14.tgz",
-      "integrity": "sha512-ERSkFtWfaxau5g5I0HVml71xghmplTh93fJ3Y+NqsU5H1d6B7nhFvI69rTMwu4fP4XETFqNE6U4g2Ztvnaa83A==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_ba": "^1.0.14"
-      }
-    },
-    "@zerobias-org/segment-zerobias-d_ba": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_ba/-/segment-zerobias-d_ba-1.0.14.tgz",
-      "integrity": "sha512-m2KhnHxoj29VAzgea9ay9JowoaYn/JankAFTXfQxsJPiHeOnN44V0pBXHFdb9VEbWiV250nH+jaZnwV4CRGHFQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
     }
   }
 }

--- a/package/zerobias/t_cs/.npmrc
+++ b/package/zerobias/t_cs/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/t_cs/index.yml
+++ b/package/zerobias/t_cs/index.yml
@@ -1,0 +1,17 @@
+id: 037b4725-57ef-4159-b5f0-4627b92a2b28
+name: Container Security
+description: Container Security
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-t_cs-segment.svg
+code: t_cs
+externalId: Container Security
+status: active
+parents: 
+  - c_is
+created: '2025-04-09T22:33:39.723827Z'
+updated: '2025-04-09T22:33:39.723827Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/t_cs/logo.svg
+++ b/package/zerobias/t_cs/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/t_cs/npm-shrinkwrap.json
+++ b/package/zerobias/t_cs/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_cs",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-t_cs",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_is": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/t_cs/package.json
+++ b/package/zerobias/t_cs/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_cs",
+  "version": "1.0.0-rc.0",
+  "description": "Container Security segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/t_cs/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.t_cs.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_is": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/t_cspm/.npmrc
+++ b/package/zerobias/t_cspm/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/t_cspm/index.yml
+++ b/package/zerobias/t_cspm/index.yml
@@ -1,0 +1,17 @@
+id: 15198a61-4625-49f0-9e32-ed9ffc88587b
+name: Cloud Security Posture Management (CSPM)
+description: Cloud Security Posture Management (CSPM)
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-t_cspm-segment.svg
+code: t_cspm
+externalId: Cloud Security Posture Management
+status: active
+parents: 
+  - c_sg
+created: '2025-04-09T22:33:55.614869Z'
+updated: '2025-04-09T22:33:55.614869Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/t_cspm/logo.svg
+++ b/package/zerobias/t_cspm/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/t_cspm/npm-shrinkwrap.json
+++ b/package/zerobias/t_cspm/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_cspm",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-t_cspm",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_sg": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/t_cspm/package.json
+++ b/package/zerobias/t_cspm/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_cspm",
+  "version": "1.0.0-rc.0",
+  "description": "Cloud Security Posture Management (CSPM) segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/t_cspm/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.t_cspm.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_sg": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/t_cvm/.npmrc
+++ b/package/zerobias/t_cvm/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/t_cvm/index.yml
+++ b/package/zerobias/t_cvm/index.yml
@@ -1,0 +1,17 @@
+id: 3a4b517b-8ae5-463b-82aa-3e4d040cbc03
+name: Continuous Vulnerability Management (CVM)
+description: Continuous Vulnerability Management (CVM)
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-t_cvm-segment.svg
+code: t_cvm
+externalId: Continuous Vulnerability Management
+status: active
+parents: 
+  - c_spao
+created: '2025-04-09T22:33:29.173471Z'
+updated: '2025-04-09T22:33:29.173471Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/t_cvm/logo.svg
+++ b/package/zerobias/t_cvm/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/t_cvm/npm-shrinkwrap.json
+++ b/package/zerobias/t_cvm/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_cvm",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-t_cvm",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_spao": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/t_cvm/package.json
+++ b/package/zerobias/t_cvm/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_cvm",
+  "version": "1.0.0-rc.0",
+  "description": "Continuous Vulnerability Management (CVM) segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/t_cvm/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.t_cvm.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_spao": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/t_cwp/.npmrc
+++ b/package/zerobias/t_cwp/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/t_cwp/index.yml
+++ b/package/zerobias/t_cwp/index.yml
@@ -1,0 +1,17 @@
+id: 298b9180-1338-49d2-b36f-4ef836b039a9
+name: Cloud Workload Protection (CWP)
+description: Cloud Workload Protection (CWP)
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-t_cwp-segment.svg
+code: t_cwp
+externalId: Cloud Workload Protection
+status: active
+parents: 
+  - c_is
+created: '2025-04-09T22:33:44.562478Z'
+updated: '2025-04-09T22:33:44.562478Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/t_cwp/logo.svg
+++ b/package/zerobias/t_cwp/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/t_cwp/npm-shrinkwrap.json
+++ b/package/zerobias/t_cwp/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_cwp",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-t_cwp",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_is": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/t_cwp/package.json
+++ b/package/zerobias/t_cwp/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_cwp",
+  "version": "1.0.0-rc.0",
+  "description": "Cloud Workload Protection (CWP) segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/t_cwp/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.t_cwp.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_is": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/t_dast/.npmrc
+++ b/package/zerobias/t_dast/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/t_dast/index.yml
+++ b/package/zerobias/t_dast/index.yml
@@ -1,0 +1,17 @@
+id: 00495ec4-84eb-4da3-afab-e95434c09b0f
+name: Dynamic Application Security Testing (DAST)
+description: Dynamic Application Security Testing (DAST)
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-t_dast-segment.svg
+code: t_dast
+externalId: Dynamic Application Security Testing
+status: active
+parents: 
+  - c_as
+created: '2025-04-09T22:33:52.139135Z'
+updated: '2025-04-09T22:33:52.139135Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/t_dast/logo.svg
+++ b/package/zerobias/t_dast/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/t_dast/npm-shrinkwrap.json
+++ b/package/zerobias/t_dast/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_dast",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-t_dast",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_as": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/t_dast/package.json
+++ b/package/zerobias/t_dast/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_dast",
+  "version": "1.0.0-rc.0",
+  "description": "Dynamic Application Security Testing (DAST) segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/t_dast/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.t_dast.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_as": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/t_dc/.npmrc
+++ b/package/zerobias/t_dc/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/t_dc/index.yml
+++ b/package/zerobias/t_dc/index.yml
@@ -1,0 +1,17 @@
+id: 276a5d8a-02f7-4d3c-ba6b-136a84a80024
+name: Device Control
+description: Device Control
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-t_dc-segment.svg
+code: t_dc
+externalId: Device Control
+status: active
+parents: 
+  - c_es
+created: '2025-04-09T22:33:50.914236Z'
+updated: '2025-04-09T22:33:50.914236Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/t_dc/logo.svg
+++ b/package/zerobias/t_dc/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/t_dc/npm-shrinkwrap.json
+++ b/package/zerobias/t_dc/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_dc",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-t_dc",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_es": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/t_dc/package.json
+++ b/package/zerobias/t_dc/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_dc",
+  "version": "1.0.0-rc.0",
+  "description": "Device Control segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/t_dc/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.t_dc.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_es": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/t_dspm/.npmrc
+++ b/package/zerobias/t_dspm/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/t_dspm/index.yml
+++ b/package/zerobias/t_dspm/index.yml
@@ -1,0 +1,17 @@
+id: d95e4f71-3dc4-4bf6-a584-2d15340c693f
+name: Data Security Posture Management (DSPM)
+description: Data Security Posture Management (DSPM)
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-t_dspm-segment.svg
+code: t_dspm
+externalId: Data Security Posture Management
+status: active
+parents: 
+  - c_sg
+created: '2025-04-09T22:33:58.998907Z'
+updated: '2025-04-09T22:33:58.998907Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/t_dspm/logo.svg
+++ b/package/zerobias/t_dspm/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/t_dspm/npm-shrinkwrap.json
+++ b/package/zerobias/t_dspm/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_dspm",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-t_dspm",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_sg": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/t_dspm/package.json
+++ b/package/zerobias/t_dspm/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_dspm",
+  "version": "1.0.0-rc.0",
+  "description": "Data Security Posture Management (DSPM) segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/t_dspm/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.t_dspm.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_sg": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/t_easm/.npmrc
+++ b/package/zerobias/t_easm/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/t_easm/index.yml
+++ b/package/zerobias/t_easm/index.yml
@@ -1,0 +1,17 @@
+id: efd65d99-e09d-49b1-8524-3c06baa75172
+name: External Attack Surface Management (EASM)
+description: External Attack Surface Management (EASM)
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-t_easm-segment.svg
+code: t_easm
+externalId: External Attack Surface Management
+status: active
+parents: 
+  - c_em
+created: '2025-04-09T22:33:24.055366Z'
+updated: '2025-04-09T22:33:24.055366Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/t_easm/logo.svg
+++ b/package/zerobias/t_easm/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/t_easm/npm-shrinkwrap.json
+++ b/package/zerobias/t_easm/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_easm",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-t_easm",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_em": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/t_easm/package.json
+++ b/package/zerobias/t_easm/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_easm",
+  "version": "1.0.0-rc.0",
+  "description": "External Attack Surface Management (EASM) segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/t_easm/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.t_easm.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_em": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/t_edlp/.npmrc
+++ b/package/zerobias/t_edlp/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/t_edlp/index.yml
+++ b/package/zerobias/t_edlp/index.yml
@@ -1,0 +1,17 @@
+id: 8dc5ac26-03c3-4a10-89fc-14fa6b4de420
+name: Endpoint Data Loss Prevention (DLP)
+description: Endpoint Data Loss Prevention (DLP)
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-t_edlp-segment.svg
+code: t_edlp
+externalId: Endpoint Data Loss Prevention
+status: active
+parents: 
+  - c_es
+created: '2025-04-09T22:33:49.923598Z'
+updated: '2025-04-09T22:33:49.923598Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/t_edlp/logo.svg
+++ b/package/zerobias/t_edlp/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/t_edlp/npm-shrinkwrap.json
+++ b/package/zerobias/t_edlp/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_edlp",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-t_edlp",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_es": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/t_edlp/package.json
+++ b/package/zerobias/t_edlp/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_edlp",
+  "version": "1.0.0-rc.0",
+  "description": "Endpoint Data Loss Prevention (DLP) segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/t_edlp/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.t_edlp.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_es": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/t_edr/.npmrc
+++ b/package/zerobias/t_edr/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/t_edr/index.yml
+++ b/package/zerobias/t_edr/index.yml
@@ -1,0 +1,17 @@
+id: 1c9f8d7c-c33d-45c8-9542-144eb02d79fb
+name: Endpoint Detection and Response (EDR)
+description: Endpoint Detection and Response (EDR)
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-t_edr-segment.svg
+code: t_edr
+externalId: Endpoint Detection and Response
+status: active
+parents: 
+  - c_es
+created: '2025-04-09T22:33:45.809165Z'
+updated: '2025-04-09T22:33:45.809165Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/t_edr/logo.svg
+++ b/package/zerobias/t_edr/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/t_edr/npm-shrinkwrap.json
+++ b/package/zerobias/t_edr/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_edr",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-t_edr",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_es": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/t_edr/package.json
+++ b/package/zerobias/t_edr/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_edr",
+  "version": "1.0.0-rc.0",
+  "description": "Endpoint Detection and Response (EDR) segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/t_edr/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.t_edr.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_es": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/t_ef/.npmrc
+++ b/package/zerobias/t_ef/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/t_ef/index.yml
+++ b/package/zerobias/t_ef/index.yml
@@ -1,0 +1,17 @@
+id: 9097926c-d31f-4f05-990b-8b71d109e22a
+name: Endpoint Firewalls
+description: Endpoint Firewalls
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-t_ef-segment.svg
+code: t_ef
+externalId: Endpoint Firewalls
+status: active
+parents: 
+  - c_es
+created: '2025-04-09T22:33:50.381106Z'
+updated: '2025-04-09T22:33:50.381106Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/t_ef/logo.svg
+++ b/package/zerobias/t_ef/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/t_ef/npm-shrinkwrap.json
+++ b/package/zerobias/t_ef/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_ef",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-t_ef",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_es": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/t_ef/package.json
+++ b/package/zerobias/t_ef/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_ef",
+  "version": "1.0.0-rc.0",
+  "description": "Endpoint Firewalls segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/t_ef/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.t_ef.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_es": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/t_epm/.npmrc
+++ b/package/zerobias/t_epm/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/t_epm/index.yml
+++ b/package/zerobias/t_epm/index.yml
@@ -1,0 +1,17 @@
+id: 2b49562a-555b-4ba8-9cf5-eda649988ca1
+name: Endpoint Patch Management
+description: Endpoint Patch Management
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-t_epm-segment.svg
+code: t_epm
+externalId: Endpoint Patch Management
+status: active
+parents: 
+  - c_es
+created: '2025-04-09T22:33:50.147667Z'
+updated: '2025-04-09T22:33:50.147667Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/t_epm/logo.svg
+++ b/package/zerobias/t_epm/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/t_epm/npm-shrinkwrap.json
+++ b/package/zerobias/t_epm/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_epm",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-t_epm",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_es": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/t_epm/package.json
+++ b/package/zerobias/t_epm/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_epm",
+  "version": "1.0.0-rc.0",
+  "description": "Endpoint Patch Management segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/t_epm/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.t_epm.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_es": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/t_erm/npm-shrinkwrap.json
+++ b/package/zerobias/t_erm/npm-shrinkwrap.json
@@ -1,84 +1,23 @@
 {
   "name": "@zerobias-org/segment-zerobias-t_erm",
-  "version": "1.0.14",
-  "lockfileVersion": 2,
+  "version": "1.0.15-rc.0",
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerobias-org/segment-zerobias-t_erm",
-      "version": "1.0.14",
+      "version": "1.0.15-rc.0",
       "license": "ISC",
       "dependencies": {
         "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-c_bsap": "^1.0.14"
+        "@zerobias-org/segment_type-zerobias": "^1.0.15-rc.0",
+        "@zerobias-org/segment-zerobias-c_bsap": "^1.0.15-rc.0"
       }
     },
     "node_modules/@auditlogic/vendor-zerobias": {
       "version": "1.0.0",
       "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
       "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "node_modules/@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-c_bsap": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-c_bsap/-/segment-zerobias-c_bsap-1.0.14.tgz",
-      "integrity": "sha512-SLetPIxgni9YqzMdB00RHiXzgCW+mx2XyGXT7wxxvaBnfcKWAoKZ4Wij2HqPJ4PsbTTvM5VOrkAD5ryEFM4NGg==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_ba": "^1.0.14"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-d_ba": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_ba/-/segment-zerobias-d_ba-1.0.14.tgz",
-      "integrity": "sha512-m2KhnHxoj29VAzgea9ay9JowoaYn/JankAFTXfQxsJPiHeOnN44V0pBXHFdb9VEbWiV250nH+jaZnwV4CRGHFQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
-    }
-  },
-  "dependencies": {
-    "@auditlogic/vendor-zerobias": {
-      "version": "1.0.0",
-      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
-      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "@zerobias-org/segment-zerobias-c_bsap": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-c_bsap/-/segment-zerobias-c_bsap-1.0.14.tgz",
-      "integrity": "sha512-SLetPIxgni9YqzMdB00RHiXzgCW+mx2XyGXT7wxxvaBnfcKWAoKZ4Wij2HqPJ4PsbTTvM5VOrkAD5ryEFM4NGg==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_ba": "^1.0.14"
-      }
-    },
-    "@zerobias-org/segment-zerobias-d_ba": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_ba/-/segment-zerobias-d_ba-1.0.14.tgz",
-      "integrity": "sha512-m2KhnHxoj29VAzgea9ay9JowoaYn/JankAFTXfQxsJPiHeOnN44V0pBXHFdb9VEbWiV250nH+jaZnwV4CRGHFQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
     }
   }
 }

--- a/package/zerobias/t_erp/npm-shrinkwrap.json
+++ b/package/zerobias/t_erp/npm-shrinkwrap.json
@@ -1,84 +1,23 @@
 {
   "name": "@zerobias-org/segment-zerobias-t_erp",
-  "version": "1.0.14",
-  "lockfileVersion": 2,
+  "version": "1.0.15-rc.0",
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerobias-org/segment-zerobias-t_erp",
-      "version": "1.0.14",
+      "version": "1.0.15-rc.0",
       "license": "ISC",
       "dependencies": {
         "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-c_bpao": "^1.0.14"
+        "@zerobias-org/segment_type-zerobias": "^1.0.15-rc.0",
+        "@zerobias-org/segment-zerobias-c_bpao": "^1.0.15-rc.0"
       }
     },
     "node_modules/@auditlogic/vendor-zerobias": {
       "version": "1.0.0",
       "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
       "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "node_modules/@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-c_bpao": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-c_bpao/-/segment-zerobias-c_bpao-1.0.14.tgz",
-      "integrity": "sha512-ERSkFtWfaxau5g5I0HVml71xghmplTh93fJ3Y+NqsU5H1d6B7nhFvI69rTMwu4fP4XETFqNE6U4g2Ztvnaa83A==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_ba": "^1.0.14"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-d_ba": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_ba/-/segment-zerobias-d_ba-1.0.14.tgz",
-      "integrity": "sha512-m2KhnHxoj29VAzgea9ay9JowoaYn/JankAFTXfQxsJPiHeOnN44V0pBXHFdb9VEbWiV250nH+jaZnwV4CRGHFQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
-    }
-  },
-  "dependencies": {
-    "@auditlogic/vendor-zerobias": {
-      "version": "1.0.0",
-      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
-      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "@zerobias-org/segment-zerobias-c_bpao": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-c_bpao/-/segment-zerobias-c_bpao-1.0.14.tgz",
-      "integrity": "sha512-ERSkFtWfaxau5g5I0HVml71xghmplTh93fJ3Y+NqsU5H1d6B7nhFvI69rTMwu4fP4XETFqNE6U4g2Ztvnaa83A==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_ba": "^1.0.14"
-      }
-    },
-    "@zerobias-org/segment-zerobias-d_ba": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_ba/-/segment-zerobias-d_ba-1.0.14.tgz",
-      "integrity": "sha512-m2KhnHxoj29VAzgea9ay9JowoaYn/JankAFTXfQxsJPiHeOnN44V0pBXHFdb9VEbWiV250nH+jaZnwV4CRGHFQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
     }
   }
 }

--- a/package/zerobias/t_hids/.npmrc
+++ b/package/zerobias/t_hids/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/t_hids/index.yml
+++ b/package/zerobias/t_hids/index.yml
@@ -1,0 +1,17 @@
+id: 0b10a1c4-641b-4152-9bf7-f6f280a280f8
+name: Host Intrusion Detection System (HIDS)
+description: Host Intrusion Detection System (HIDS)
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-t_hids-segment.svg
+code: t_hids
+externalId: Host Intrusion Detection System
+status: active
+parents: 
+  - c_is
+created: '2025-04-09T22:33:42.526341Z'
+updated: '2025-04-09T22:33:42.526341Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/t_hids/logo.svg
+++ b/package/zerobias/t_hids/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/t_hids/npm-shrinkwrap.json
+++ b/package/zerobias/t_hids/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_hids",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-t_hids",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_is": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/t_hids/package.json
+++ b/package/zerobias/t_hids/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_hids",
+  "version": "1.0.0-rc.0",
+  "description": "Host Intrusion Detection System (HIDS) segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/t_hids/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.t_hids.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_is": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/t_hips/.npmrc
+++ b/package/zerobias/t_hips/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/t_hips/index.yml
+++ b/package/zerobias/t_hips/index.yml
@@ -1,0 +1,17 @@
+id: 16902e4e-43a7-41bb-a0a0-6562e7c89b72
+name: Host-based Intrusion Prevention System (HIPS)
+description: Host-based Intrusion Prevention System (HIPS)
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-t_hips-segment.svg
+code: t_hips
+externalId: Host-based Intrusion Prevention System
+status: active
+parents: 
+  - c_es
+created: '2025-04-09T22:33:50.610475Z'
+updated: '2025-04-09T22:33:50.610475Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/t_hips/logo.svg
+++ b/package/zerobias/t_hips/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/t_hips/npm-shrinkwrap.json
+++ b/package/zerobias/t_hips/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_hips",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-t_hips",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_es": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/t_hips/package.json
+++ b/package/zerobias/t_hips/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_hips",
+  "version": "1.0.0-rc.0",
+  "description": "Host-based Intrusion Prevention System (HIPS) segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/t_hips/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.t_hips.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_es": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/t_hrm/npm-shrinkwrap.json
+++ b/package/zerobias/t_hrm/npm-shrinkwrap.json
@@ -1,84 +1,23 @@
 {
   "name": "@zerobias-org/segment-zerobias-t_hrm",
-  "version": "1.0.14",
-  "lockfileVersion": 2,
+  "version": "1.0.15-rc.0",
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerobias-org/segment-zerobias-t_hrm",
-      "version": "1.0.14",
+      "version": "1.0.15-rc.0",
       "license": "ISC",
       "dependencies": {
         "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-c_bpao": "^1.0.14"
+        "@zerobias-org/segment_type-zerobias": "^1.0.15-rc.0",
+        "@zerobias-org/segment-zerobias-c_bpao": "^1.0.15-rc.0"
       }
     },
     "node_modules/@auditlogic/vendor-zerobias": {
       "version": "1.0.0",
       "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
       "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "node_modules/@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-c_bpao": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-c_bpao/-/segment-zerobias-c_bpao-1.0.14.tgz",
-      "integrity": "sha512-ERSkFtWfaxau5g5I0HVml71xghmplTh93fJ3Y+NqsU5H1d6B7nhFvI69rTMwu4fP4XETFqNE6U4g2Ztvnaa83A==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_ba": "^1.0.14"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-d_ba": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_ba/-/segment-zerobias-d_ba-1.0.14.tgz",
-      "integrity": "sha512-m2KhnHxoj29VAzgea9ay9JowoaYn/JankAFTXfQxsJPiHeOnN44V0pBXHFdb9VEbWiV250nH+jaZnwV4CRGHFQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
-    }
-  },
-  "dependencies": {
-    "@auditlogic/vendor-zerobias": {
-      "version": "1.0.0",
-      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
-      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "@zerobias-org/segment-zerobias-c_bpao": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-c_bpao/-/segment-zerobias-c_bpao-1.0.14.tgz",
-      "integrity": "sha512-ERSkFtWfaxau5g5I0HVml71xghmplTh93fJ3Y+NqsU5H1d6B7nhFvI69rTMwu4fP4XETFqNE6U4g2Ztvnaa83A==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_ba": "^1.0.14"
-      }
-    },
-    "@zerobias-org/segment-zerobias-d_ba": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_ba/-/segment-zerobias-d_ba-1.0.14.tgz",
-      "integrity": "sha512-m2KhnHxoj29VAzgea9ay9JowoaYn/JankAFTXfQxsJPiHeOnN44V0pBXHFdb9VEbWiV250nH+jaZnwV4CRGHFQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
     }
   }
 }

--- a/package/zerobias/t_iacs/.npmrc
+++ b/package/zerobias/t_iacs/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/t_iacs/index.yml
+++ b/package/zerobias/t_iacs/index.yml
@@ -1,0 +1,17 @@
+id: d8880622-5a59-49b6-acba-49ad08c49d4d
+name: Infrastructure as Code Security (IaC Sec)
+description: Infrastructure as Code Security (IaC Sec)
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-t_iacs-segment.svg
+code: t_iacs
+externalId: Infrastructure as Code Security
+status: active
+parents: 
+  - c_is
+created: '2025-04-09T22:33:38.482263Z'
+updated: '2025-04-09T22:33:38.482263Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/t_iacs/logo.svg
+++ b/package/zerobias/t_iacs/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/t_iacs/npm-shrinkwrap.json
+++ b/package/zerobias/t_iacs/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_iacs",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-t_iacs",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_is": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/t_iacs/package.json
+++ b/package/zerobias/t_iacs/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_iacs",
+  "version": "1.0.0-rc.0",
+  "description": "Infrastructure as Code Security (IaC Sec) segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/t_iacs/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.t_iacs.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_is": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/t_iam/npm-shrinkwrap.json
+++ b/package/zerobias/t_iam/npm-shrinkwrap.json
@@ -1,84 +1,23 @@
 {
   "name": "@zerobias-org/segment-zerobias-t_iam",
-  "version": "1.0.14",
-  "lockfileVersion": 2,
+  "version": "1.0.15-rc.0",
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerobias-org/segment-zerobias-t_iam",
-      "version": "1.0.14",
+      "version": "1.0.15-rc.0",
       "license": "ISC",
       "dependencies": {
         "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-c_itg": "^1.0.14"
+        "@zerobias-org/segment_type-zerobias": "^1.0.15-rc.0",
+        "@zerobias-org/segment-zerobias-c_itg": "^1.0.15-rc.0"
       }
     },
     "node_modules/@auditlogic/vendor-zerobias": {
       "version": "1.0.0",
       "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
       "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "node_modules/@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-c_itg": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-c_itg/-/segment-zerobias-c_itg-1.0.14.tgz",
-      "integrity": "sha512-myFsuGAU6yB5yy+e/UGefRHGVGFIBTaGCiXuGVZGpcT29JKWvoSEHYNBI7sNGksJfgWZch0iIBprXIiybIFzhw==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_itm": "^1.0.14"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-d_itm": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_itm/-/segment-zerobias-d_itm-1.0.14.tgz",
-      "integrity": "sha512-9JLGIBm8E9kJL20Fo+kmrLG13xXI2GAC3lpv4xWit46J8q4ROhuFDkcpp40w1hS3BJC00K1QuHhlaC5vW5Dw6w==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
-    }
-  },
-  "dependencies": {
-    "@auditlogic/vendor-zerobias": {
-      "version": "1.0.0",
-      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
-      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "@zerobias-org/segment-zerobias-c_itg": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-c_itg/-/segment-zerobias-c_itg-1.0.14.tgz",
-      "integrity": "sha512-myFsuGAU6yB5yy+e/UGefRHGVGFIBTaGCiXuGVZGpcT29JKWvoSEHYNBI7sNGksJfgWZch0iIBprXIiybIFzhw==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_itm": "^1.0.14"
-      }
-    },
-    "@zerobias-org/segment-zerobias-d_itm": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_itm/-/segment-zerobias-d_itm-1.0.14.tgz",
-      "integrity": "sha512-9JLGIBm8E9kJL20Fo+kmrLG13xXI2GAC3lpv4xWit46J8q4ROhuFDkcpp40w1hS3BJC00K1QuHhlaC5vW5Dw6w==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
     }
   }
 }

--- a/package/zerobias/t_iast/.npmrc
+++ b/package/zerobias/t_iast/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/t_iast/index.yml
+++ b/package/zerobias/t_iast/index.yml
@@ -1,0 +1,17 @@
+id: 7a8033a0-030d-4bdc-a6fb-c48c2803c0ca
+name: Interactive Application Security Testing
+description: Interactive Application Security Testing
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-t_iast-segment.svg
+code: t_iast
+externalId: Interactive Application Security Testing
+status: active
+parents: 
+  - c_as
+created: '2025-04-09T22:33:52.360463Z'
+updated: '2025-04-09T22:33:52.360463Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/t_iast/logo.svg
+++ b/package/zerobias/t_iast/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/t_iast/npm-shrinkwrap.json
+++ b/package/zerobias/t_iast/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_iast",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-t_iast",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_as": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/t_iast/package.json
+++ b/package/zerobias/t_iast/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_iast",
+  "version": "1.0.0-rc.0",
+  "description": "Interactive Application Security Testing segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/t_iast/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.t_iast.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_as": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/t_ids/.npmrc
+++ b/package/zerobias/t_ids/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/t_ids/index.yml
+++ b/package/zerobias/t_ids/index.yml
@@ -1,0 +1,17 @@
+id: 07a4373d-cbc2-4bdf-909f-8a4d8346110b
+name: Intrusion Detection System (IDS)
+description: Intrusion Detection System (IDS)
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-t_ids-segment.svg
+code: t_ids
+externalId: Intrusion Detection System
+status: active
+parents: 
+  - c_ns
+created: '2025-04-09T22:33:36.057228Z'
+updated: '2025-04-09T22:33:36.057228Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/t_ids/logo.svg
+++ b/package/zerobias/t_ids/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/t_ids/npm-shrinkwrap.json
+++ b/package/zerobias/t_ids/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_ids",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-t_ids",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_ns": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/t_ids/package.json
+++ b/package/zerobias/t_ids/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_ids",
+  "version": "1.0.0-rc.0",
+  "description": "Intrusion Detection System (IDS) segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/t_ids/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.t_ids.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_ns": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/t_idsec/.npmrc
+++ b/package/zerobias/t_idsec/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/t_idsec/index.yml
+++ b/package/zerobias/t_idsec/index.yml
@@ -1,0 +1,17 @@
+id: 017ecfa6-0892-40e9-9e80-0c7d81b97f76
+name: Identity Security (ID Sec)
+description: Identity Security (ID Sec)
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-t_idsec-segment.svg
+code: t_idsec
+externalId: Identity Security
+status: active
+parents: 
+  - c_as
+created: '2025-04-09T22:33:54.658684Z'
+updated: '2025-04-09T22:33:54.658684Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/t_idsec/logo.svg
+++ b/package/zerobias/t_idsec/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/t_idsec/npm-shrinkwrap.json
+++ b/package/zerobias/t_idsec/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_idsec",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-t_idsec",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_as": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/t_idsec/package.json
+++ b/package/zerobias/t_idsec/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_idsec",
+  "version": "1.0.0-rc.0",
+  "description": "Identity Security (ID Sec) segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/t_idsec/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.t_idsec.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_as": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/t_itam/npm-shrinkwrap.json
+++ b/package/zerobias/t_itam/npm-shrinkwrap.json
@@ -1,84 +1,23 @@
 {
   "name": "@zerobias-org/segment-zerobias-t_itam",
-  "version": "1.0.14",
-  "lockfileVersion": 2,
+  "version": "1.0.15-rc.0",
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerobias-org/segment-zerobias-t_itam",
-      "version": "1.0.14",
+      "version": "1.0.15-rc.0",
       "license": "ISC",
       "dependencies": {
         "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-c_itpao": "^1.0.14"
+        "@zerobias-org/segment_type-zerobias": "^1.0.15-rc.0",
+        "@zerobias-org/segment-zerobias-c_itpao": "^1.0.15-rc.0"
       }
     },
     "node_modules/@auditlogic/vendor-zerobias": {
       "version": "1.0.0",
       "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
       "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "node_modules/@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-c_itpao": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-c_itpao/-/segment-zerobias-c_itpao-1.0.14.tgz",
-      "integrity": "sha512-uGnsCiEq18RCnvC7kMoRvpZMwwr0iOA+pODFFPTvt5Abvpr+Qgq7Bcy0f+FcFYAvao44J6TJTuFTsAIohN50vQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_itm": "^1.0.14"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-d_itm": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_itm/-/segment-zerobias-d_itm-1.0.14.tgz",
-      "integrity": "sha512-9JLGIBm8E9kJL20Fo+kmrLG13xXI2GAC3lpv4xWit46J8q4ROhuFDkcpp40w1hS3BJC00K1QuHhlaC5vW5Dw6w==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
-    }
-  },
-  "dependencies": {
-    "@auditlogic/vendor-zerobias": {
-      "version": "1.0.0",
-      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
-      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "@zerobias-org/segment-zerobias-c_itpao": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-c_itpao/-/segment-zerobias-c_itpao-1.0.14.tgz",
-      "integrity": "sha512-uGnsCiEq18RCnvC7kMoRvpZMwwr0iOA+pODFFPTvt5Abvpr+Qgq7Bcy0f+FcFYAvao44J6TJTuFTsAIohN50vQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_itm": "^1.0.14"
-      }
-    },
-    "@zerobias-org/segment-zerobias-d_itm": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_itm/-/segment-zerobias-d_itm-1.0.14.tgz",
-      "integrity": "sha512-9JLGIBm8E9kJL20Fo+kmrLG13xXI2GAC3lpv4xWit46J8q4ROhuFDkcpp40w1hS3BJC00K1QuHhlaC5vW5Dw6w==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
     }
   }
 }

--- a/package/zerobias/t_itd/npm-shrinkwrap.json
+++ b/package/zerobias/t_itd/npm-shrinkwrap.json
@@ -1,84 +1,23 @@
 {
   "name": "@zerobias-org/segment-zerobias-t_itd",
-  "version": "1.0.14",
-  "lockfileVersion": 2,
+  "version": "1.0.15-rc.0",
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerobias-org/segment-zerobias-t_itd",
-      "version": "1.0.14",
+      "version": "1.0.15-rc.0",
       "license": "ISC",
       "dependencies": {
         "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-c_itpao": "^1.0.14"
+        "@zerobias-org/segment_type-zerobias": "^1.0.15-rc.0",
+        "@zerobias-org/segment-zerobias-c_itpao": "^1.0.15-rc.0"
       }
     },
     "node_modules/@auditlogic/vendor-zerobias": {
       "version": "1.0.0",
       "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
       "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "node_modules/@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-c_itpao": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-c_itpao/-/segment-zerobias-c_itpao-1.0.14.tgz",
-      "integrity": "sha512-uGnsCiEq18RCnvC7kMoRvpZMwwr0iOA+pODFFPTvt5Abvpr+Qgq7Bcy0f+FcFYAvao44J6TJTuFTsAIohN50vQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_itm": "^1.0.14"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-d_itm": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_itm/-/segment-zerobias-d_itm-1.0.14.tgz",
-      "integrity": "sha512-9JLGIBm8E9kJL20Fo+kmrLG13xXI2GAC3lpv4xWit46J8q4ROhuFDkcpp40w1hS3BJC00K1QuHhlaC5vW5Dw6w==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
-    }
-  },
-  "dependencies": {
-    "@auditlogic/vendor-zerobias": {
-      "version": "1.0.0",
-      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
-      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "@zerobias-org/segment-zerobias-c_itpao": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-c_itpao/-/segment-zerobias-c_itpao-1.0.14.tgz",
-      "integrity": "sha512-uGnsCiEq18RCnvC7kMoRvpZMwwr0iOA+pODFFPTvt5Abvpr+Qgq7Bcy0f+FcFYAvao44J6TJTuFTsAIohN50vQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_itm": "^1.0.14"
-      }
-    },
-    "@zerobias-org/segment-zerobias-d_itm": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_itm/-/segment-zerobias-d_itm-1.0.14.tgz",
-      "integrity": "sha512-9JLGIBm8E9kJL20Fo+kmrLG13xXI2GAC3lpv4xWit46J8q4ROhuFDkcpp40w1hS3BJC00K1QuHhlaC5vW5Dw6w==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
     }
   }
 }

--- a/package/zerobias/t_itrm/npm-shrinkwrap.json
+++ b/package/zerobias/t_itrm/npm-shrinkwrap.json
@@ -1,84 +1,23 @@
 {
   "name": "@zerobias-org/segment-zerobias-t_itrm",
-  "version": "1.0.14",
-  "lockfileVersion": 2,
+  "version": "1.0.15-rc.0",
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerobias-org/segment-zerobias-t_itrm",
-      "version": "1.0.14",
+      "version": "1.0.15-rc.0",
       "license": "ISC",
       "dependencies": {
         "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-c_itg": "^1.0.14"
+        "@zerobias-org/segment_type-zerobias": "^1.0.15-rc.0",
+        "@zerobias-org/segment-zerobias-c_itg": "^1.0.15-rc.0"
       }
     },
     "node_modules/@auditlogic/vendor-zerobias": {
       "version": "1.0.0",
       "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
       "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "node_modules/@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-c_itg": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-c_itg/-/segment-zerobias-c_itg-1.0.14.tgz",
-      "integrity": "sha512-myFsuGAU6yB5yy+e/UGefRHGVGFIBTaGCiXuGVZGpcT29JKWvoSEHYNBI7sNGksJfgWZch0iIBprXIiybIFzhw==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_itm": "^1.0.14"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-d_itm": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_itm/-/segment-zerobias-d_itm-1.0.14.tgz",
-      "integrity": "sha512-9JLGIBm8E9kJL20Fo+kmrLG13xXI2GAC3lpv4xWit46J8q4ROhuFDkcpp40w1hS3BJC00K1QuHhlaC5vW5Dw6w==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
-    }
-  },
-  "dependencies": {
-    "@auditlogic/vendor-zerobias": {
-      "version": "1.0.0",
-      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
-      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "@zerobias-org/segment-zerobias-c_itg": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-c_itg/-/segment-zerobias-c_itg-1.0.14.tgz",
-      "integrity": "sha512-myFsuGAU6yB5yy+e/UGefRHGVGFIBTaGCiXuGVZGpcT29JKWvoSEHYNBI7sNGksJfgWZch0iIBprXIiybIFzhw==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_itm": "^1.0.14"
-      }
-    },
-    "@zerobias-org/segment-zerobias-d_itm": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_itm/-/segment-zerobias-d_itm-1.0.14.tgz",
-      "integrity": "sha512-9JLGIBm8E9kJL20Fo+kmrLG13xXI2GAC3lpv4xWit46J8q4ROhuFDkcpp40w1hS3BJC00K1QuHhlaC5vW5Dw6w==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
     }
   }
 }

--- a/package/zerobias/t_itsm/npm-shrinkwrap.json
+++ b/package/zerobias/t_itsm/npm-shrinkwrap.json
@@ -1,84 +1,23 @@
 {
   "name": "@zerobias-org/segment-zerobias-t_itsm",
-  "version": "1.0.14",
-  "lockfileVersion": 2,
+  "version": "1.0.15-rc.0",
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerobias-org/segment-zerobias-t_itsm",
-      "version": "1.0.14",
+      "version": "1.0.15-rc.0",
       "license": "ISC",
       "dependencies": {
         "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-c_itpao": "^1.0.14"
+        "@zerobias-org/segment_type-zerobias": "^1.0.15-rc.0",
+        "@zerobias-org/segment-zerobias-c_itpao": "^1.0.15-rc.0"
       }
     },
     "node_modules/@auditlogic/vendor-zerobias": {
       "version": "1.0.0",
       "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
       "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "node_modules/@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-c_itpao": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-c_itpao/-/segment-zerobias-c_itpao-1.0.14.tgz",
-      "integrity": "sha512-uGnsCiEq18RCnvC7kMoRvpZMwwr0iOA+pODFFPTvt5Abvpr+Qgq7Bcy0f+FcFYAvao44J6TJTuFTsAIohN50vQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_itm": "^1.0.14"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-d_itm": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_itm/-/segment-zerobias-d_itm-1.0.14.tgz",
-      "integrity": "sha512-9JLGIBm8E9kJL20Fo+kmrLG13xXI2GAC3lpv4xWit46J8q4ROhuFDkcpp40w1hS3BJC00K1QuHhlaC5vW5Dw6w==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
-    }
-  },
-  "dependencies": {
-    "@auditlogic/vendor-zerobias": {
-      "version": "1.0.0",
-      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
-      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "@zerobias-org/segment-zerobias-c_itpao": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-c_itpao/-/segment-zerobias-c_itpao-1.0.14.tgz",
-      "integrity": "sha512-uGnsCiEq18RCnvC7kMoRvpZMwwr0iOA+pODFFPTvt5Abvpr+Qgq7Bcy0f+FcFYAvao44J6TJTuFTsAIohN50vQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_itm": "^1.0.14"
-      }
-    },
-    "@zerobias-org/segment-zerobias-d_itm": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_itm/-/segment-zerobias-d_itm-1.0.14.tgz",
-      "integrity": "sha512-9JLGIBm8E9kJL20Fo+kmrLG13xXI2GAC3lpv4xWit46J8q4ROhuFDkcpp40w1hS3BJC00K1QuHhlaC5vW5Dw6w==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
     }
   }
 }

--- a/package/zerobias/t_kspm/.npmrc
+++ b/package/zerobias/t_kspm/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/t_kspm/index.yml
+++ b/package/zerobias/t_kspm/index.yml
@@ -1,0 +1,17 @@
+id: 3e505674-d6ad-4abb-8a1d-2ae4ff73e064
+name: Kubernetes Security Posture Management (KSPM)
+description: Kubernetes Security Posture Management (KSPM)
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-t_kspm-segment.svg
+code: t_kspm
+externalId: Kubernetes Security Posture Management
+status: active
+parents: 
+  - c_sg
+created: '2025-04-09T22:33:58.733675Z'
+updated: '2025-04-09T22:33:58.733675Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/t_kspm/logo.svg
+++ b/package/zerobias/t_kspm/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/t_kspm/npm-shrinkwrap.json
+++ b/package/zerobias/t_kspm/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_kspm",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-t_kspm",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_sg": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/t_kspm/package.json
+++ b/package/zerobias/t_kspm/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_kspm",
+  "version": "1.0.0-rc.0",
+  "description": "Kubernetes Security Posture Management (KSPM) segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/t_kspm/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.t_kspm.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_sg": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/t_mdm/index.yml
+++ b/package/zerobias/t_mdm/index.yml
@@ -1,4 +1,4 @@
-id: b199f396-0ee5-4a86-916f-d68873b63483
+id: 155cd70b-b13a-4fd1-80eb-92fe3134ae6e
 name: Mobile Device Management (MDM)
 description: Mobile Device Management (MDM)
 segmentType: tool
@@ -8,9 +8,9 @@ code: t_mdm
 externalId: Mobile Device Management
 status: active
 parents: 
-  - c_devices
-created: '2025-04-02T04:23:38.561795Z'
-updated: '2025-04-02T04:23:38.561795Z'
+  - c_es
+created: '2025-04-09T22:33:49.697361Z'
+updated: '2025-04-09T22:33:49.697361Z'
 tags: []
 environment: prod
 hostname: https://api.app.zerobias.com

--- a/package/zerobias/t_mdm/npm-shrinkwrap.json
+++ b/package/zerobias/t_mdm/npm-shrinkwrap.json
@@ -1,17 +1,17 @@
 {
   "name": "@zerobias-org/segment-zerobias-t_mdm",
-  "version": "1.0.14",
-  "lockfileVersion": 2,
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerobias-org/segment-zerobias-t_mdm",
-      "version": "1.0.14",
+      "version": "1.0.0-rc.0",
       "license": "ISC",
       "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-c_devices": "^1.0.14"
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_es": "^1.0.0-rc.0"
       }
     },
     "node_modules/@auditlogic/vendor-zerobias": {
@@ -25,59 +25,6 @@
       "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
       "dependencies": {
         "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-c_devices": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-c_devices/-/segment-zerobias-c_devices-1.0.14.tgz",
-      "integrity": "sha512-Nu9VMcpBgYTghDCd4rA0L+B2DizVanx2HaPPEmcec6GQ5yFlPAvC1zd8yT6BgA+QS8/T83wH4bbcgLYmRTHXlA==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_itm": "^1.0.14"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-d_itm": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_itm/-/segment-zerobias-d_itm-1.0.14.tgz",
-      "integrity": "sha512-9JLGIBm8E9kJL20Fo+kmrLG13xXI2GAC3lpv4xWit46J8q4ROhuFDkcpp40w1hS3BJC00K1QuHhlaC5vW5Dw6w==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
-    }
-  },
-  "dependencies": {
-    "@auditlogic/vendor-zerobias": {
-      "version": "1.0.0",
-      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
-      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "@zerobias-org/segment-zerobias-c_devices": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-c_devices/-/segment-zerobias-c_devices-1.0.14.tgz",
-      "integrity": "sha512-Nu9VMcpBgYTghDCd4rA0L+B2DizVanx2HaPPEmcec6GQ5yFlPAvC1zd8yT6BgA+QS8/T83wH4bbcgLYmRTHXlA==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_itm": "^1.0.14"
-      }
-    },
-    "@zerobias-org/segment-zerobias-d_itm": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_itm/-/segment-zerobias-d_itm-1.0.14.tgz",
-      "integrity": "sha512-9JLGIBm8E9kJL20Fo+kmrLG13xXI2GAC3lpv4xWit46J8q4ROhuFDkcpp40w1hS3BJC00K1QuHhlaC5vW5Dw6w==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
       }
     }
   }

--- a/package/zerobias/t_mdm/package.json
+++ b/package/zerobias/t_mdm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zerobias-org/segment-zerobias-t_mdm",
-  "version": "1.0.15-rc.0",
+  "version": "1.0.0-rc.0",
   "description": "Mobile Device Management (MDM) segment artifact",
   "author": "opignault@zerobias.com",
   "license": "ISC",
@@ -27,8 +27,8 @@
     "package": "zerobias.t_mdm.segment"
   },
   "dependencies": {
-    "@auditlogic/vendor-zerobias": "^1.0.0",
-    "@zerobias-org/segment-zerobias-c_devices": "^1.0.15-rc.0",
-    "@zerobias-org/segment_type-zerobias": "^1.0.15-rc.0"
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_es": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
   }
 }

--- a/package/zerobias/t_ngav/.npmrc
+++ b/package/zerobias/t_ngav/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/t_ngav/index.yml
+++ b/package/zerobias/t_ngav/index.yml
@@ -1,0 +1,17 @@
+id: 83d61629-6ac5-4ba5-82ce-65b1bb57397c
+name: Next-generation antivirus (NGAV)
+description: Next-generation antivirus (NGAV)
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-t_ngav-segment.svg
+code: t_ngav
+externalId: Next-generation antivirus
+status: active
+parents: 
+  - c_es
+created: '2025-04-09T22:33:49.177346Z'
+updated: '2025-04-09T22:33:49.177346Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/t_ngav/logo.svg
+++ b/package/zerobias/t_ngav/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/t_ngav/npm-shrinkwrap.json
+++ b/package/zerobias/t_ngav/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_ngav",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-t_ngav",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_es": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/t_ngav/package.json
+++ b/package/zerobias/t_ngav/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_ngav",
+  "version": "1.0.0-rc.0",
+  "description": "Next-generation antivirus (NGAV) segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/t_ngav/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.t_ngav.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_es": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/t_ntao/npm-shrinkwrap.json
+++ b/package/zerobias/t_ntao/npm-shrinkwrap.json
@@ -1,84 +1,23 @@
 {
   "name": "@zerobias-org/segment-zerobias-t_ntao",
-  "version": "1.0.14",
-  "lockfileVersion": 2,
+  "version": "1.0.15-rc.0",
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerobias-org/segment-zerobias-t_ntao",
-      "version": "1.0.14",
+      "version": "1.0.15-rc.0",
       "license": "ISC",
       "dependencies": {
         "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-c_op": "^1.0.14"
+        "@zerobias-org/segment_type-zerobias": "^1.0.15-rc.0",
+        "@zerobias-org/segment-zerobias-c_op": "^1.0.15-rc.0"
       }
     },
     "node_modules/@auditlogic/vendor-zerobias": {
       "version": "1.0.0",
       "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
       "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "node_modules/@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-c_op": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-c_op/-/segment-zerobias-c_op-1.0.14.tgz",
-      "integrity": "sha512-+ovx6zOsLePQf0YmsKicmEgokNkwwBeCFTYabz9hWY3y6KCQ0bYZn7BsGgOYEGQ2WGx3e99J0sc1G3deAPpRag==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_ba": "^1.0.14"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-d_ba": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_ba/-/segment-zerobias-d_ba-1.0.14.tgz",
-      "integrity": "sha512-m2KhnHxoj29VAzgea9ay9JowoaYn/JankAFTXfQxsJPiHeOnN44V0pBXHFdb9VEbWiV250nH+jaZnwV4CRGHFQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
-    }
-  },
-  "dependencies": {
-    "@auditlogic/vendor-zerobias": {
-      "version": "1.0.0",
-      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
-      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "@zerobias-org/segment-zerobias-c_op": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-c_op/-/segment-zerobias-c_op-1.0.14.tgz",
-      "integrity": "sha512-+ovx6zOsLePQf0YmsKicmEgokNkwwBeCFTYabz9hWY3y6KCQ0bYZn7BsGgOYEGQ2WGx3e99J0sc1G3deAPpRag==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_ba": "^1.0.14"
-      }
-    },
-    "@zerobias-org/segment-zerobias-d_ba": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_ba/-/segment-zerobias-d_ba-1.0.14.tgz",
-      "integrity": "sha512-m2KhnHxoj29VAzgea9ay9JowoaYn/JankAFTXfQxsJPiHeOnN44V0pBXHFdb9VEbWiV250nH+jaZnwV4CRGHFQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
     }
   }
 }

--- a/package/zerobias/t_pm/npm-shrinkwrap.json
+++ b/package/zerobias/t_pm/npm-shrinkwrap.json
@@ -1,105 +1,24 @@
 {
   "name": "@zerobias-org/segment-zerobias-t_pm",
-  "version": "1.0.14",
-  "lockfileVersion": 2,
+  "version": "1.0.15-rc.0",
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerobias-org/segment-zerobias-t_pm",
-      "version": "1.0.14",
+      "version": "1.0.15-rc.0",
       "license": "ISC",
       "dependencies": {
         "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-c_devices": "^1.0.14",
-        "@zerobias-org/segment-zerobias-c_nasa": "^1.0.14"
+        "@zerobias-org/segment_type-zerobias": "^1.0.15-rc.0",
+        "@zerobias-org/segment-zerobias-c_devices": "^1.0.15-rc.0",
+        "@zerobias-org/segment-zerobias-c_nasa": "^1.0.15-rc.0"
       }
     },
     "node_modules/@auditlogic/vendor-zerobias": {
       "version": "1.0.0",
       "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
       "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "node_modules/@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-c_devices": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-c_devices/-/segment-zerobias-c_devices-1.0.14.tgz",
-      "integrity": "sha512-Nu9VMcpBgYTghDCd4rA0L+B2DizVanx2HaPPEmcec6GQ5yFlPAvC1zd8yT6BgA+QS8/T83wH4bbcgLYmRTHXlA==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_itm": "^1.0.14"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-c_nasa": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-c_nasa/-/segment-zerobias-c_nasa-1.0.14.tgz",
-      "integrity": "sha512-DghomjZfUjnodaWH8YvGTwTW3oJ/kbQRvOCFbp260Ovb36Kjly+kNTBfIVx/zkilAdKj4TLfm/y1Iaqx6aZoDA==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_itm": "^1.0.14"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-d_itm": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_itm/-/segment-zerobias-d_itm-1.0.14.tgz",
-      "integrity": "sha512-9JLGIBm8E9kJL20Fo+kmrLG13xXI2GAC3lpv4xWit46J8q4ROhuFDkcpp40w1hS3BJC00K1QuHhlaC5vW5Dw6w==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
-    }
-  },
-  "dependencies": {
-    "@auditlogic/vendor-zerobias": {
-      "version": "1.0.0",
-      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
-      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "@zerobias-org/segment-zerobias-c_devices": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-c_devices/-/segment-zerobias-c_devices-1.0.14.tgz",
-      "integrity": "sha512-Nu9VMcpBgYTghDCd4rA0L+B2DizVanx2HaPPEmcec6GQ5yFlPAvC1zd8yT6BgA+QS8/T83wH4bbcgLYmRTHXlA==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_itm": "^1.0.14"
-      }
-    },
-    "@zerobias-org/segment-zerobias-c_nasa": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-c_nasa/-/segment-zerobias-c_nasa-1.0.14.tgz",
-      "integrity": "sha512-DghomjZfUjnodaWH8YvGTwTW3oJ/kbQRvOCFbp260Ovb36Kjly+kNTBfIVx/zkilAdKj4TLfm/y1Iaqx6aZoDA==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_itm": "^1.0.14"
-      }
-    },
-    "@zerobias-org/segment-zerobias-d_itm": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_itm/-/segment-zerobias-d_itm-1.0.14.tgz",
-      "integrity": "sha512-9JLGIBm8E9kJL20Fo+kmrLG13xXI2GAC3lpv4xWit46J8q4ROhuFDkcpp40w1hS3BJC00K1QuHhlaC5vW5Dw6w==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
     }
   }
 }

--- a/package/zerobias/t_pmatm/npm-shrinkwrap.json
+++ b/package/zerobias/t_pmatm/npm-shrinkwrap.json
@@ -1,84 +1,23 @@
 {
   "name": "@zerobias-org/segment-zerobias-t_pmatm",
-  "version": "1.0.14",
-  "lockfileVersion": 2,
+  "version": "1.0.15-rc.0",
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerobias-org/segment-zerobias-t_pmatm",
-      "version": "1.0.14",
+      "version": "1.0.15-rc.0",
       "license": "ISC",
       "dependencies": {
         "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-c_op": "^1.0.14"
+        "@zerobias-org/segment_type-zerobias": "^1.0.15-rc.0",
+        "@zerobias-org/segment-zerobias-c_op": "^1.0.15-rc.0"
       }
     },
     "node_modules/@auditlogic/vendor-zerobias": {
       "version": "1.0.0",
       "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
       "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "node_modules/@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-c_op": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-c_op/-/segment-zerobias-c_op-1.0.14.tgz",
-      "integrity": "sha512-+ovx6zOsLePQf0YmsKicmEgokNkwwBeCFTYabz9hWY3y6KCQ0bYZn7BsGgOYEGQ2WGx3e99J0sc1G3deAPpRag==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_ba": "^1.0.14"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-d_ba": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_ba/-/segment-zerobias-d_ba-1.0.14.tgz",
-      "integrity": "sha512-m2KhnHxoj29VAzgea9ay9JowoaYn/JankAFTXfQxsJPiHeOnN44V0pBXHFdb9VEbWiV250nH+jaZnwV4CRGHFQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
-    }
-  },
-  "dependencies": {
-    "@auditlogic/vendor-zerobias": {
-      "version": "1.0.0",
-      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
-      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "@zerobias-org/segment-zerobias-c_op": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-c_op/-/segment-zerobias-c_op-1.0.14.tgz",
-      "integrity": "sha512-+ovx6zOsLePQf0YmsKicmEgokNkwwBeCFTYabz9hWY3y6KCQ0bYZn7BsGgOYEGQ2WGx3e99J0sc1G3deAPpRag==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_ba": "^1.0.14"
-      }
-    },
-    "@zerobias-org/segment-zerobias-d_ba": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_ba/-/segment-zerobias-d_ba-1.0.14.tgz",
-      "integrity": "sha512-m2KhnHxoj29VAzgea9ay9JowoaYn/JankAFTXfQxsJPiHeOnN44V0pBXHFdb9VEbWiV250nH+jaZnwV4CRGHFQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
     }
   }
 }

--- a/package/zerobias/t_psa/npm-shrinkwrap.json
+++ b/package/zerobias/t_psa/npm-shrinkwrap.json
@@ -1,84 +1,23 @@
 {
   "name": "@zerobias-org/segment-zerobias-t_psa",
-  "version": "1.0.14",
-  "lockfileVersion": 2,
+  "version": "1.0.15-rc.0",
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerobias-org/segment-zerobias-t_psa",
-      "version": "1.0.14",
+      "version": "1.0.15-rc.0",
       "license": "ISC",
       "dependencies": {
         "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-c_itpao": "^1.0.14"
+        "@zerobias-org/segment_type-zerobias": "^1.0.15-rc.0",
+        "@zerobias-org/segment-zerobias-c_itpao": "^1.0.15-rc.0"
       }
     },
     "node_modules/@auditlogic/vendor-zerobias": {
       "version": "1.0.0",
       "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
       "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "node_modules/@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-c_itpao": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-c_itpao/-/segment-zerobias-c_itpao-1.0.14.tgz",
-      "integrity": "sha512-uGnsCiEq18RCnvC7kMoRvpZMwwr0iOA+pODFFPTvt5Abvpr+Qgq7Bcy0f+FcFYAvao44J6TJTuFTsAIohN50vQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_itm": "^1.0.14"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-d_itm": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_itm/-/segment-zerobias-d_itm-1.0.14.tgz",
-      "integrity": "sha512-9JLGIBm8E9kJL20Fo+kmrLG13xXI2GAC3lpv4xWit46J8q4ROhuFDkcpp40w1hS3BJC00K1QuHhlaC5vW5Dw6w==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
-    }
-  },
-  "dependencies": {
-    "@auditlogic/vendor-zerobias": {
-      "version": "1.0.0",
-      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
-      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "@zerobias-org/segment-zerobias-c_itpao": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-c_itpao/-/segment-zerobias-c_itpao-1.0.14.tgz",
-      "integrity": "sha512-uGnsCiEq18RCnvC7kMoRvpZMwwr0iOA+pODFFPTvt5Abvpr+Qgq7Bcy0f+FcFYAvao44J6TJTuFTsAIohN50vQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_itm": "^1.0.14"
-      }
-    },
-    "@zerobias-org/segment-zerobias-d_itm": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_itm/-/segment-zerobias-d_itm-1.0.14.tgz",
-      "integrity": "sha512-9JLGIBm8E9kJL20Fo+kmrLG13xXI2GAC3lpv4xWit46J8q4ROhuFDkcpp40w1hS3BJC00K1QuHhlaC5vW5Dw6w==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
     }
   }
 }

--- a/package/zerobias/t_rasp/.npmrc
+++ b/package/zerobias/t_rasp/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/t_rasp/index.yml
+++ b/package/zerobias/t_rasp/index.yml
@@ -1,0 +1,17 @@
+id: 918af823-4b0f-438c-a93b-8596274abb7e
+name: Runtime Application Self-Protection (RASP)
+description: Runtime Application Self-Protection (RASP)
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-t_rasp-segment.svg
+code: t_rasp
+externalId: Runtime Application Self-Protection
+status: active
+parents: 
+  - c_as
+created: '2025-04-09T22:33:52.591442Z'
+updated: '2025-04-09T22:33:52.591442Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/t_rasp/logo.svg
+++ b/package/zerobias/t_rasp/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/t_rasp/npm-shrinkwrap.json
+++ b/package/zerobias/t_rasp/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_rasp",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-t_rasp",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_as": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/t_rasp/package.json
+++ b/package/zerobias/t_rasp/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_rasp",
+  "version": "1.0.0-rc.0",
+  "description": "Runtime Application Self-Protection (RASP) segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/t_rasp/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.t_rasp.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_as": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/t_rbvm/.npmrc
+++ b/package/zerobias/t_rbvm/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/t_rbvm/index.yml
+++ b/package/zerobias/t_rbvm/index.yml
@@ -1,0 +1,17 @@
+id: 848a64aa-4fbf-423f-bf8e-c631ca1ce2e3
+name: Risk-Based Vulnerability Management (RBVM)
+description: Risk-Based Vulnerability Management (RBVM)
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-t_rbvm-segment.svg
+code: t_rbvm
+externalId: Risk-Based Vulnerability Management
+status: active
+parents: 
+  - c_em
+created: '2025-04-09T22:33:24.712317Z'
+updated: '2025-04-09T22:33:24.712317Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/t_rbvm/logo.svg
+++ b/package/zerobias/t_rbvm/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/t_rbvm/npm-shrinkwrap.json
+++ b/package/zerobias/t_rbvm/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_rbvm",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-t_rbvm",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_em": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/t_rbvm/package.json
+++ b/package/zerobias/t_rbvm/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_rbvm",
+  "version": "1.0.0-rc.0",
+  "description": "Risk-Based Vulnerability Management (RBVM) segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/t_rbvm/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.t_rbvm.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_em": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/t_rmm/npm-shrinkwrap.json
+++ b/package/zerobias/t_rmm/npm-shrinkwrap.json
@@ -1,105 +1,24 @@
 {
   "name": "@zerobias-org/segment-zerobias-t_rmm",
-  "version": "1.0.14",
-  "lockfileVersion": 2,
+  "version": "1.0.15-rc.0",
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerobias-org/segment-zerobias-t_rmm",
-      "version": "1.0.14",
+      "version": "1.0.15-rc.0",
       "license": "ISC",
       "dependencies": {
         "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-c_devices": "^1.0.14",
-        "@zerobias-org/segment-zerobias-c_nasa": "^1.0.14"
+        "@zerobias-org/segment_type-zerobias": "^1.0.15-rc.0",
+        "@zerobias-org/segment-zerobias-c_devices": "^1.0.15-rc.0",
+        "@zerobias-org/segment-zerobias-c_nasa": "^1.0.15-rc.0"
       }
     },
     "node_modules/@auditlogic/vendor-zerobias": {
       "version": "1.0.0",
       "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
       "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "node_modules/@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-c_devices": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-c_devices/-/segment-zerobias-c_devices-1.0.14.tgz",
-      "integrity": "sha512-Nu9VMcpBgYTghDCd4rA0L+B2DizVanx2HaPPEmcec6GQ5yFlPAvC1zd8yT6BgA+QS8/T83wH4bbcgLYmRTHXlA==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_itm": "^1.0.14"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-c_nasa": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-c_nasa/-/segment-zerobias-c_nasa-1.0.14.tgz",
-      "integrity": "sha512-DghomjZfUjnodaWH8YvGTwTW3oJ/kbQRvOCFbp260Ovb36Kjly+kNTBfIVx/zkilAdKj4TLfm/y1Iaqx6aZoDA==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_itm": "^1.0.14"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-d_itm": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_itm/-/segment-zerobias-d_itm-1.0.14.tgz",
-      "integrity": "sha512-9JLGIBm8E9kJL20Fo+kmrLG13xXI2GAC3lpv4xWit46J8q4ROhuFDkcpp40w1hS3BJC00K1QuHhlaC5vW5Dw6w==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
-    }
-  },
-  "dependencies": {
-    "@auditlogic/vendor-zerobias": {
-      "version": "1.0.0",
-      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
-      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "@zerobias-org/segment-zerobias-c_devices": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-c_devices/-/segment-zerobias-c_devices-1.0.14.tgz",
-      "integrity": "sha512-Nu9VMcpBgYTghDCd4rA0L+B2DizVanx2HaPPEmcec6GQ5yFlPAvC1zd8yT6BgA+QS8/T83wH4bbcgLYmRTHXlA==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_itm": "^1.0.14"
-      }
-    },
-    "@zerobias-org/segment-zerobias-c_nasa": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-c_nasa/-/segment-zerobias-c_nasa-1.0.14.tgz",
-      "integrity": "sha512-DghomjZfUjnodaWH8YvGTwTW3oJ/kbQRvOCFbp260Ovb36Kjly+kNTBfIVx/zkilAdKj4TLfm/y1Iaqx6aZoDA==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_itm": "^1.0.14"
-      }
-    },
-    "@zerobias-org/segment-zerobias-d_itm": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_itm/-/segment-zerobias-d_itm-1.0.14.tgz",
-      "integrity": "sha512-9JLGIBm8E9kJL20Fo+kmrLG13xXI2GAC3lpv4xWit46J8q4ROhuFDkcpp40w1hS3BJC00K1QuHhlaC5vW5Dw6w==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
     }
   }
 }

--- a/package/zerobias/t_sast/.npmrc
+++ b/package/zerobias/t_sast/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/t_sast/index.yml
+++ b/package/zerobias/t_sast/index.yml
@@ -1,0 +1,17 @@
+id: fdff27cd-f64a-40c4-9e44-29a5af9bda94
+name: Static Application Security Testing (SAST)
+description: Static Application Security Testing (SAST)
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-t_sast-segment.svg
+code: t_sast
+externalId: Static Application Security Testing
+status: active
+parents: 
+  - c_as
+created: '2025-04-09T22:33:51.916356Z'
+updated: '2025-04-09T22:33:51.916356Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/t_sast/logo.svg
+++ b/package/zerobias/t_sast/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/t_sast/npm-shrinkwrap.json
+++ b/package/zerobias/t_sast/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_sast",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-t_sast",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_as": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/t_sast/package.json
+++ b/package/zerobias/t_sast/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_sast",
+  "version": "1.0.0-rc.0",
+  "description": "Static Application Security Testing (SAST) segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/t_sast/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.t_sast.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_as": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/t_sbom/.npmrc
+++ b/package/zerobias/t_sbom/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/t_sbom/index.yml
+++ b/package/zerobias/t_sbom/index.yml
@@ -1,0 +1,17 @@
+id: 65ed19ec-6f3c-451b-901d-caac0ffdfd92
+name: Software Bill of Materials (SBOM)
+description: Software Bill of Materials (SBOM)
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-t_sbom-segment.svg
+code: t_sbom
+externalId: Software Bill of Materials
+status: active
+parents: 
+  - c_sg
+created: '2025-04-09T22:33:55.361925Z'
+updated: '2025-04-09T22:33:55.361925Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/t_sbom/logo.svg
+++ b/package/zerobias/t_sbom/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/t_sbom/npm-shrinkwrap.json
+++ b/package/zerobias/t_sbom/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_sbom",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-t_sbom",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_sg": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/t_sbom/package.json
+++ b/package/zerobias/t_sbom/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_sbom",
+  "version": "1.0.0-rc.0",
+  "description": "Software Bill of Materials (SBOM) segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/t_sbom/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.t_sbom.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_sg": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/t_sca/.npmrc
+++ b/package/zerobias/t_sca/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/t_sca/index.yml
+++ b/package/zerobias/t_sca/index.yml
@@ -1,0 +1,17 @@
+id: ea83c64d-6596-4d3c-8f3c-b6e6361a7a83
+name: Software Composition Analysis (SCA)
+description: Software Composition Analysis (SCA)
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-t_sca-segment.svg
+code: t_sca
+externalId: Software Composition Analysis
+status: active
+parents: 
+  - c_as
+created: '2025-04-09T22:33:51.657411Z'
+updated: '2025-04-09T22:33:51.657411Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/t_sca/logo.svg
+++ b/package/zerobias/t_sca/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/t_sca/npm-shrinkwrap.json
+++ b/package/zerobias/t_sca/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_sca",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-t_sca",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_as": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/t_sca/package.json
+++ b/package/zerobias/t_sca/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_sca",
+  "version": "1.0.0-rc.0",
+  "description": "Software Composition Analysis (SCA) segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/t_sca/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.t_sca.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_as": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/t_scm/npm-shrinkwrap.json
+++ b/package/zerobias/t_scm/npm-shrinkwrap.json
@@ -1,84 +1,23 @@
 {
   "name": "@zerobias-org/segment-zerobias-t_scm",
-  "version": "1.0.14",
-  "lockfileVersion": 2,
+  "version": "1.0.15-rc.0",
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerobias-org/segment-zerobias-t_scm",
-      "version": "1.0.14",
+      "version": "1.0.15-rc.0",
       "license": "ISC",
       "dependencies": {
         "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-c_bpao": "^1.0.14"
+        "@zerobias-org/segment_type-zerobias": "^1.0.15-rc.0",
+        "@zerobias-org/segment-zerobias-c_bpao": "^1.0.15-rc.0"
       }
     },
     "node_modules/@auditlogic/vendor-zerobias": {
       "version": "1.0.0",
       "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
       "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "node_modules/@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-c_bpao": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-c_bpao/-/segment-zerobias-c_bpao-1.0.14.tgz",
-      "integrity": "sha512-ERSkFtWfaxau5g5I0HVml71xghmplTh93fJ3Y+NqsU5H1d6B7nhFvI69rTMwu4fP4XETFqNE6U4g2Ztvnaa83A==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_ba": "^1.0.14"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-d_ba": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_ba/-/segment-zerobias-d_ba-1.0.14.tgz",
-      "integrity": "sha512-m2KhnHxoj29VAzgea9ay9JowoaYn/JankAFTXfQxsJPiHeOnN44V0pBXHFdb9VEbWiV250nH+jaZnwV4CRGHFQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
-    }
-  },
-  "dependencies": {
-    "@auditlogic/vendor-zerobias": {
-      "version": "1.0.0",
-      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
-      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "@zerobias-org/segment-zerobias-c_bpao": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-c_bpao/-/segment-zerobias-c_bpao-1.0.14.tgz",
-      "integrity": "sha512-ERSkFtWfaxau5g5I0HVml71xghmplTh93fJ3Y+NqsU5H1d6B7nhFvI69rTMwu4fP4XETFqNE6U4g2Ztvnaa83A==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_ba": "^1.0.14"
-      }
-    },
-    "@zerobias-org/segment-zerobias-d_ba": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_ba/-/segment-zerobias-d_ba-1.0.14.tgz",
-      "integrity": "sha512-m2KhnHxoj29VAzgea9ay9JowoaYn/JankAFTXfQxsJPiHeOnN44V0pBXHFdb9VEbWiV250nH+jaZnwV4CRGHFQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
     }
   }
 }

--- a/package/zerobias/t_siem/.npmrc
+++ b/package/zerobias/t_siem/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/t_siem/index.yml
+++ b/package/zerobias/t_siem/index.yml
@@ -1,0 +1,17 @@
+id: 1e1e508b-d9f3-4a82-a17d-9c8bd122332e
+name: Security Information and Event Management (SIEM)
+description: Security Information and Event Management (SIEM)
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-t_siem-segment.svg
+code: t_siem
+externalId: Security Information and Event Management
+status: active
+parents: 
+  - c_spao
+created: '2025-04-09T22:33:32.450003Z'
+updated: '2025-04-09T22:33:32.450003Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/t_siem/logo.svg
+++ b/package/zerobias/t_siem/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/t_siem/npm-shrinkwrap.json
+++ b/package/zerobias/t_siem/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_siem",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-t_siem",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_spao": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/t_siem/package.json
+++ b/package/zerobias/t_siem/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_siem",
+  "version": "1.0.0-rc.0",
+  "description": "Security Information and Event Management (SIEM) segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/t_siem/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.t_siem.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_spao": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/t_sspm/.npmrc
+++ b/package/zerobias/t_sspm/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/t_sspm/index.yml
+++ b/package/zerobias/t_sspm/index.yml
@@ -1,0 +1,17 @@
+id: a5ae4f27-a72a-47d5-8d28-55db4fa7fba3
+name: SaaS Security Posture Management (SSPM)
+description: SaaS Security Posture Management (SSPM)
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-t_sspm-segment.svg
+code: t_sspm
+externalId: SaaS Security Posture Management
+status: active
+parents: 
+  - c_sg
+created: '2025-04-09T22:33:59.672689Z'
+updated: '2025-04-09T22:33:59.672689Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/t_sspm/logo.svg
+++ b/package/zerobias/t_sspm/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/t_sspm/npm-shrinkwrap.json
+++ b/package/zerobias/t_sspm/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_sspm",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-t_sspm",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_sg": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/t_sspm/package.json
+++ b/package/zerobias/t_sspm/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_sspm",
+  "version": "1.0.0-rc.0",
+  "description": "SaaS Security Posture Management (SSPM) segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/t_sspm/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.t_sspm.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_sg": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/t_ttas/npm-shrinkwrap.json
+++ b/package/zerobias/t_ttas/npm-shrinkwrap.json
@@ -1,84 +1,23 @@
 {
   "name": "@zerobias-org/segment-zerobias-t_ttas",
-  "version": "1.0.14",
-  "lockfileVersion": 2,
+  "version": "1.0.15-rc.0",
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerobias-org/segment-zerobias-t_ttas",
-      "version": "1.0.14",
+      "version": "1.0.15-rc.0",
       "license": "ISC",
       "dependencies": {
         "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-c_op": "^1.0.14"
+        "@zerobias-org/segment_type-zerobias": "^1.0.15-rc.0",
+        "@zerobias-org/segment-zerobias-c_op": "^1.0.15-rc.0"
       }
     },
     "node_modules/@auditlogic/vendor-zerobias": {
       "version": "1.0.0",
       "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
       "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "node_modules/@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-c_op": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-c_op/-/segment-zerobias-c_op-1.0.14.tgz",
-      "integrity": "sha512-+ovx6zOsLePQf0YmsKicmEgokNkwwBeCFTYabz9hWY3y6KCQ0bYZn7BsGgOYEGQ2WGx3e99J0sc1G3deAPpRag==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_ba": "^1.0.14"
-      }
-    },
-    "node_modules/@zerobias-org/segment-zerobias-d_ba": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_ba/-/segment-zerobias-d_ba-1.0.14.tgz",
-      "integrity": "sha512-m2KhnHxoj29VAzgea9ay9JowoaYn/JankAFTXfQxsJPiHeOnN44V0pBXHFdb9VEbWiV250nH+jaZnwV4CRGHFQ==",
-      "dependencies": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
-    }
-  },
-  "dependencies": {
-    "@auditlogic/vendor-zerobias": {
-      "version": "1.0.0",
-      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
-      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
-    },
-    "@zerobias-org/segment_type-zerobias": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
-      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0"
-      }
-    },
-    "@zerobias-org/segment-zerobias-c_op": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-c_op/-/segment-zerobias-c_op-1.0.14.tgz",
-      "integrity": "sha512-+ovx6zOsLePQf0YmsKicmEgokNkwwBeCFTYabz9hWY3y6KCQ0bYZn7BsGgOYEGQ2WGx3e99J0sc1G3deAPpRag==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14",
-        "@zerobias-org/segment-zerobias-d_ba": "^1.0.14"
-      }
-    },
-    "@zerobias-org/segment-zerobias-d_ba": {
-      "version": "1.0.14",
-      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment-zerobias-d_ba/-/segment-zerobias-d_ba-1.0.14.tgz",
-      "integrity": "sha512-m2KhnHxoj29VAzgea9ay9JowoaYn/JankAFTXfQxsJPiHeOnN44V0pBXHFdb9VEbWiV250nH+jaZnwV4CRGHFQ==",
-      "requires": {
-        "@auditlogic/vendor-zerobias": "^1.0.0",
-        "@zerobias-org/segment_type-zerobias": "^1.0.14"
-      }
     }
   }
 }

--- a/package/zerobias/t_waf/.npmrc
+++ b/package/zerobias/t_waf/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/t_waf/index.yml
+++ b/package/zerobias/t_waf/index.yml
@@ -1,0 +1,17 @@
+id: ee964fca-588a-41aa-bfd9-d628e4e782a0
+name: Web Application Firewalls (WAFs)
+description: Web Application Firewalls (WAFs)
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-t_waf-segment.svg
+code: t_waf
+externalId: Web Application Firewalls
+status: active
+parents: 
+  - c_is
+created: '2025-04-09T22:33:44.911534Z'
+updated: '2025-04-09T22:33:44.911534Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/t_waf/logo.svg
+++ b/package/zerobias/t_waf/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/t_waf/npm-shrinkwrap.json
+++ b/package/zerobias/t_waf/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_waf",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-t_waf",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_is": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/t_waf/package.json
+++ b/package/zerobias/t_waf/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_waf",
+  "version": "1.0.0-rc.0",
+  "description": "Web Application Firewalls (WAFs) segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/t_waf/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.t_waf.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_is": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}

--- a/package/zerobias/t_xdr/.npmrc
+++ b/package/zerobias/t_xdr/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/t_xdr/index.yml
+++ b/package/zerobias/t_xdr/index.yml
@@ -1,0 +1,17 @@
+id: 0111ff4f-106e-4f96-a6df-cf3b9d0c5e6c
+name: Extended Detection and Response (XDR)
+description: Extended Detection and Response (XDR)
+segmentType: tool
+ownerId: 00000000-0000-0000-0000-000000000000
+imageUrl: https://cdn.auditmation.io/logos/zerobias-t_xdr-segment.svg
+code: t_xdr
+externalId: Extended Detection and Response
+status: active
+parents: 
+  - c_es
+created: '2025-04-09T22:33:48.703054Z'
+updated: '2025-04-09T22:33:48.703054Z'
+tags: []
+environment: prod
+hostname: https://api.app.zerobias.com
+aliases: []

--- a/package/zerobias/t_xdr/logo.svg
+++ b/package/zerobias/t_xdr/logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg fill="#000000" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 24 24" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<g id="surface1">
+	<path d="M19,3c0,2.2-4.3,6-9,6v6c4.7,0,9,3.6,9,6h2v-7.3c0.6-0.3,1-1,1-1.7s-0.4-1.4-1-1.7V3H19z M5,9c-0.8,0-1.5,0.5-1.8,1.2
+		C2.5,10.5,2,11.2,2,12s0.5,1.5,1.2,1.8C3.5,14.5,4.2,15,5,15h0.2l2.2,7l3.5-1.1L9,15V9H5z"/>
+</g>
+<rect class="st0" width="24" height="24"/>
+</svg>

--- a/package/zerobias/t_xdr/npm-shrinkwrap.json
+++ b/package/zerobias/t_xdr/npm-shrinkwrap.json
@@ -1,0 +1,31 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_xdr",
+  "version": "1.0.0-rc.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@zerobias-org/segment-zerobias-t_xdr",
+      "version": "1.0.0-rc.0",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0",
+        "@zerobias-org/segment-zerobias-c_es": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@auditlogic/vendor-zerobias": {
+      "version": "1.0.0",
+      "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
+      "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/segment_type-zerobias": {
+      "version": "1.0.14",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/segment_type-zerobias/-/segment_type-zerobias-1.0.14.tgz",
+      "integrity": "sha512-oYwwUq/7FcvLBS8JLlgG93tuRepHYa2qPfrCpe+gxzC+1mFYvbUcXifRKCAOtK/UOVcZMgPdbmpZppDlE3MkzQ==",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "^1.0.0"
+      }
+    }
+  }
+}

--- a/package/zerobias/t_xdr/package.json
+++ b/package/zerobias/t_xdr/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@zerobias-org/segment-zerobias-t_xdr",
+  "version": "1.0.0-rc.0",
+  "description": "Extended Detection and Response (XDR) segment artifact",
+  "author": "opignault@zerobias.com",
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:zerobias-org/segment.git",
+    "directory": "package/zerobias/t_xdr/"
+  },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "nx:prepublish": "../../../scripts/prepublish.sh",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "files": [
+    "index.yml",
+    "logo.svg"
+  ],
+  "auditmation": {
+    "dataloader-version": "3.4.5",
+    "import-artifact": "segment",
+    "package": "zerobias.t_xdr.segment"
+  },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "^1.0.0-rc.0",
+    "@zerobias-org/segment-zerobias-c_es": "^1.0.0-rc.0",
+    "@zerobias-org/segment_type-zerobias": "^1.0.0-rc.0"
+  }
+}


### PR DESCRIPTION
This is my second batch of segments for the ZeroBias catalog. It contains 1 domain, 7 categories, 3 feature groups, and 48 tools. 'npm run validate' was successful on my local dev branch. 