### PR TITLE
chore: drop root workspaces + align settings.gradle.kts with org/module

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,5 @@
     "@commitlint/config-conventional": "^12.0.1",
     "husky": "^5.1.3",
     "tsx": "^4.21.0"
-  },
-  "workspaces": [
-    "package/**"
-  ]
+  }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,9 +1,14 @@
+// settings.gradle.kts — segment monorepo
+//
+// Plugin resolution order: mavenLocal (for `publishToMavenLocal` dev builds
+// of build-tools) → GitHub Packages Maven → gradle plugin portal → mavenCentral.
+// Never via `includeBuild` of a sibling repo path: dev iteration goes through
+// `./gradlew publishToMavenLocal` from build-tools so CI and local resolve
+// the artifact the same way.
+
 pluginManagement {
-    val localBuildTools = file("../util/packages/build-tools")
-    if (localBuildTools.exists()) {
-        includeBuild(localBuildTools)
-    }
     repositories {
+        mavenLocal()
         maven {
             url = uri("https://maven.pkg.github.com/zerobias-org/util")
             credentials {


### PR DESCRIPTION
## Summary

Two cleanups Chris flagged in Slack, applied per the template merged at zerobias-org/vendor#71.

- **Root `package.json`**: remove `"workspaces": ["package/**"]`. Hoisted root install was blocking per-package `package-lock.json` files; the publish flow checks for them and runs `npm shrinkwrap` before publishing.
- **`settings.gradle.kts`**: align `pluginManagement` with [`org/module`](https://github.com/zerobias-org/module/blob/main/settings.gradle.kts). Drop `includeBuild("../util/packages/build-tools")` (sibling-path resolution) and resolve via `mavenLocal -> maven pkg -> portal -> mavenCentral`. Dev iteration goes through `./gradlew publishToMavenLocal` from build-tools so CI and local resolve the artifact the same way. Repo-specific bits (`rootProject.name`, plugin set, auto-discover comment) preserved.

`[skip ci]` since no `package/**/build.gradle.kts` changed.

## Test plan

- [x] `./gradlew projectPaths` still resolves all projects after the change
- [ ] Verify the `publish.yml` workflow's `detect` job correctly skips (no package builds changed)

Generated with [Claude Code](https://claude.com/claude-code)
