### PR TITLE
feat(services): add Services domain segment (d_svc) - L0 of 3

### DIFF
--- a/package/zerobias/d_svc/.npmrc
+++ b/package/zerobias/d_svc/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/d_svc/build.gradle.kts
+++ b/package/zerobias/d_svc/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/d_svc/gate-stamp.json
+++ b/package/zerobias/d_svc/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments",
+  "sourceHash": "98b9a7e27e4873a145558413a415f65ec55c85364024f1a2c2caf7c1f6f3a124",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/d_svc/index.yml
+++ b/package/zerobias/d_svc/index.yml
@@ -1,0 +1,11 @@
+id: 4160e9a9-90d9-4de0-89b0-ca8e213298f3
+name: Services
+description: Professional and managed services offered by providers in the marketplace.
+segmentType: domain
+imageUrl: https://cdn.auditmation.io/logos/zerobias-d_svc-segment.svg
+code: d_svc
+externalId: Services
+status: published
+parents: []
+tags: []
+aliases: []

--- a/package/zerobias/d_svc/package.json
+++ b/package/zerobias/d_svc/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@zerobias-org/segment-zerobias-d_svc",
+  "version": "1.0.0-rc.1",
+  "description": "Professional and managed services offered by providers in the marketplace.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/d_svc/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.d_svc.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/zbb.yaml
+++ b/zbb.yaml
@@ -6,6 +6,18 @@ version: "1.0.0"
 # as vendor / tag / module). The task creates and deletes its own branch
 # via the Neon API.
 env:
+  # ZeroBias platform API key. The dataloader-service /branches call
+  # (NeonDataloaderTask) authenticates with this; it also satisfies the
+  # pkg.zerobias.org registry. `source: env` whitelists it through zbb's
+  # hermetic seal (gate's BASE_CREDS contract does NOT include it).
+  # Must be a superuser or org-admin principal, else the service returns 403.
+  ZB_TOKEN:
+    type: string
+    source: env
+    description: ZeroBias platform API key for the dataloader-service and ZB registry
+    required: true
+    mask: true
+
   NEON_API_KEY:
     source: vault
     vault: "operations-kv/neon/content.api-key"


### PR DESCRIPTION
Top-level domain of the Services taxonomy, published first per Chris (2026-06-12): inside-dep publishing is no longer allowed, so parents must be published before children.

This is L0 (the d_svc domain). The 37 category segments (L1, c_*) and 131 service segments (L2, s_*) follow in sequential PRs, each opened only after its parent level is published to npm.

Also declares ZB_TOKEN in zbb.yaml env (source: env) so zbb 1.0.4's hermetic seal passes it through to the dataloader-service gate.

@Daniel: deliberately scoped to one level; pinging for the approved label.