### PR TITLE
feat(services): add 37 service-category segments (c_*) - L1 of 3

### DIFF
--- a/package/zerobias/c_accessibility/.npmrc
+++ b/package/zerobias/c_accessibility/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/c_accessibility/build.gradle.kts
+++ b/package/zerobias/c_accessibility/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/c_accessibility/gate-stamp.json
+++ b/package/zerobias/c_accessibility/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l1-categories",
+  "sourceHash": "d489d42aadb1c1eea77b497e8045737b5824f2210fa37a269a6e85a2bad31727",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/c_accessibility/index.yml
+++ b/package/zerobias/c_accessibility/index.yml
@@ -1,0 +1,12 @@
+id: 6f1e42c3-f7e1-4613-ba89-8927a2314549
+name: Accessibility Compliance
+description: Accessibility auditing and remediation services.
+segmentType: category
+imageUrl: https://cdn.auditmation.io/logos/zerobias-c_accessibility-segment.svg
+code: c_accessibility
+externalId: Accessibility Compliance
+status: published
+parents:
+  - d_svc
+tags: []
+aliases: []

--- a/package/zerobias/c_accessibility/package.json
+++ b/package/zerobias/c_accessibility/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_accessibility",
+  "version": "1.0.0-rc.1",
+  "description": "Accessibility auditing and remediation services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/c_accessibility/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.c_accessibility.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-d_svc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/c_advisory/.npmrc
+++ b/package/zerobias/c_advisory/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/c_advisory/build.gradle.kts
+++ b/package/zerobias/c_advisory/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/c_advisory/gate-stamp.json
+++ b/package/zerobias/c_advisory/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l1-categories",
+  "sourceHash": "041e79f8537de6b818c6a5d9a161a8dca57558cd55ba6899910e27887d598b14",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/c_advisory/index.yml
+++ b/package/zerobias/c_advisory/index.yml
@@ -1,0 +1,12 @@
+id: 0a67ce37-899e-4ba9-ac82-5bbac591491a
+name: Advisory and Consulting
+description: Business strategy, process, and financial advisory services.
+segmentType: category
+imageUrl: https://cdn.auditmation.io/logos/zerobias-c_advisory-segment.svg
+code: c_advisory
+externalId: Advisory and Consulting
+status: published
+parents:
+  - d_svc
+tags: []
+aliases: []

--- a/package/zerobias/c_advisory/package.json
+++ b/package/zerobias/c_advisory/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_advisory",
+  "version": "1.0.0-rc.1",
+  "description": "Business strategy, process, and financial advisory services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/c_advisory/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.c_advisory.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-d_svc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/c_ai/.npmrc
+++ b/package/zerobias/c_ai/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/c_ai/build.gradle.kts
+++ b/package/zerobias/c_ai/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/c_ai/gate-stamp.json
+++ b/package/zerobias/c_ai/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l1-categories",
+  "sourceHash": "38529ac29db00cfefa898613190fb1fe21a400db9a042047de053aec0b9c45bb",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/c_ai/index.yml
+++ b/package/zerobias/c_ai/index.yml
@@ -1,0 +1,12 @@
+id: 006020c2-0477-4880-83e6-b30dc7a21c9d
+name: AI Governance and Security
+description: Artificial intelligence governance and security services.
+segmentType: category
+imageUrl: https://cdn.auditmation.io/logos/zerobias-c_ai-segment.svg
+code: c_ai
+externalId: AI Governance and Security
+status: published
+parents:
+  - d_svc
+tags: []
+aliases: []

--- a/package/zerobias/c_ai/package.json
+++ b/package/zerobias/c_ai/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_ai",
+  "version": "1.0.0-rc.1",
+  "description": "Artificial intelligence governance and security services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/c_ai/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.c_ai.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-d_svc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/c_appsec/.npmrc
+++ b/package/zerobias/c_appsec/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/c_appsec/build.gradle.kts
+++ b/package/zerobias/c_appsec/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/c_appsec/gate-stamp.json
+++ b/package/zerobias/c_appsec/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l1-categories",
+  "sourceHash": "75a62dce2ff37288e4aa7a51393cef48c5bda76d0bf1644fa964ee9556f2d3c5",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/c_appsec/index.yml
+++ b/package/zerobias/c_appsec/index.yml
@@ -1,0 +1,12 @@
+id: dbfb680e-56d4-4145-80a9-68fd94558010
+name: Application Security
+description: Application and software security services.
+segmentType: category
+imageUrl: https://cdn.auditmation.io/logos/zerobias-c_appsec-segment.svg
+code: c_appsec
+externalId: Application Security
+status: published
+parents:
+  - d_svc
+tags: []
+aliases: []

--- a/package/zerobias/c_appsec/package.json
+++ b/package/zerobias/c_appsec/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_appsec",
+  "version": "1.0.0-rc.1",
+  "description": "Application and software security services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/c_appsec/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.c_appsec.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-d_svc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/c_asset/.npmrc
+++ b/package/zerobias/c_asset/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/c_asset/build.gradle.kts
+++ b/package/zerobias/c_asset/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/c_asset/gate-stamp.json
+++ b/package/zerobias/c_asset/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l1-categories",
+  "sourceHash": "c9ef1f6ecf4bce7087c2546ca518210e9d776b18c385b3e5cf05cc4ea40c0699",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/c_asset/index.yml
+++ b/package/zerobias/c_asset/index.yml
@@ -1,0 +1,12 @@
+id: 109285e4-7acc-4a71-98c9-8d86c90c2123
+name: IT Asset Management
+description: IT and software asset management services.
+segmentType: category
+imageUrl: https://cdn.auditmation.io/logos/zerobias-c_asset-segment.svg
+code: c_asset
+externalId: IT Asset Management
+status: published
+parents:
+  - d_svc
+tags: []
+aliases: []

--- a/package/zerobias/c_asset/package.json
+++ b/package/zerobias/c_asset/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_asset",
+  "version": "1.0.0-rc.1",
+  "description": "IT and software asset management services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/c_asset/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.c_asset.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-d_svc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/c_audit/.npmrc
+++ b/package/zerobias/c_audit/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/c_audit/build.gradle.kts
+++ b/package/zerobias/c_audit/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/c_audit/gate-stamp.json
+++ b/package/zerobias/c_audit/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l1-categories",
+  "sourceHash": "26eb2f733f622def964e8397f5d6fe6041d2051be9861bcf2053dfa9dded9f7f",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/c_audit/index.yml
+++ b/package/zerobias/c_audit/index.yml
@@ -1,0 +1,12 @@
+id: 0f9c6042-2f83-4db8-a794-c2609154f7d5
+name: Audit and Certification
+description: Compliance audit, framework readiness, and certification services.
+segmentType: category
+imageUrl: https://cdn.auditmation.io/logos/zerobias-c_audit-segment.svg
+code: c_audit
+externalId: Audit and Certification
+status: published
+parents:
+  - d_svc
+tags: []
+aliases: []

--- a/package/zerobias/c_audit/package.json
+++ b/package/zerobias/c_audit/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_audit",
+  "version": "1.0.0-rc.1",
+  "description": "Compliance audit, framework readiness, and certification services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/c_audit/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.c_audit.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-d_svc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/c_bizcert/.npmrc
+++ b/package/zerobias/c_bizcert/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/c_bizcert/build.gradle.kts
+++ b/package/zerobias/c_bizcert/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/c_bizcert/gate-stamp.json
+++ b/package/zerobias/c_bizcert/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l1-categories",
+  "sourceHash": "9bf37d4f5344359bac473328ca1e95c30196a5f7962589e4084a171e591e8d98",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/c_bizcert/index.yml
+++ b/package/zerobias/c_bizcert/index.yml
@@ -1,0 +1,12 @@
+id: ba949857-6c4a-4f8b-88ef-af0e5e364bb7
+name: Business Certifications and Registrations
+description: Business certification, registration, and eligibility services.
+segmentType: category
+imageUrl: https://cdn.auditmation.io/logos/zerobias-c_bizcert-segment.svg
+code: c_bizcert
+externalId: Business Certifications and Registrations
+status: published
+parents:
+  - d_svc
+tags: []
+aliases: []

--- a/package/zerobias/c_bizcert/package.json
+++ b/package/zerobias/c_bizcert/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_bizcert",
+  "version": "1.0.0-rc.1",
+  "description": "Business certification, registration, and eligibility services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/c_bizcert/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.c_bizcert.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-d_svc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/c_cloudsec/.npmrc
+++ b/package/zerobias/c_cloudsec/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/c_cloudsec/build.gradle.kts
+++ b/package/zerobias/c_cloudsec/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/c_cloudsec/gate-stamp.json
+++ b/package/zerobias/c_cloudsec/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l1-categories",
+  "sourceHash": "ffffef7fa848ee947a68e96d68e0ae1e6c900b06113ff23b15ef640bb00d2b72",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/c_cloudsec/index.yml
+++ b/package/zerobias/c_cloudsec/index.yml
@@ -1,0 +1,12 @@
+id: b2b2d2b6-02ca-4a70-9849-b87d1a49b291
+name: Cloud Security
+description: Cloud security posture and protection services.
+segmentType: category
+imageUrl: https://cdn.auditmation.io/logos/zerobias-c_cloudsec-segment.svg
+code: c_cloudsec
+externalId: Cloud Security
+status: published
+parents:
+  - d_svc
+tags: []
+aliases: []

--- a/package/zerobias/c_cloudsec/package.json
+++ b/package/zerobias/c_cloudsec/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_cloudsec",
+  "version": "1.0.0-rc.1",
+  "description": "Cloud security posture and protection services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/c_cloudsec/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.c_cloudsec.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-d_svc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/c_commsvc/.npmrc
+++ b/package/zerobias/c_commsvc/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/c_commsvc/build.gradle.kts
+++ b/package/zerobias/c_commsvc/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/c_commsvc/gate-stamp.json
+++ b/package/zerobias/c_commsvc/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l1-categories",
+  "sourceHash": "5ee00d88717496bef1fe4c5f86d0a5d4ff38a2f959648b137828ba57aa1a7a4f",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/c_commsvc/index.yml
+++ b/package/zerobias/c_commsvc/index.yml
@@ -1,0 +1,12 @@
+id: 84127017-82d0-4c08-ab20-4d6250bfb63e
+name: Communications
+description: Telecommunications and managed communications services.
+segmentType: category
+imageUrl: https://cdn.auditmation.io/logos/zerobias-c_commsvc-segment.svg
+code: c_commsvc
+externalId: Communications
+status: published
+parents:
+  - d_svc
+tags: []
+aliases: []

--- a/package/zerobias/c_commsvc/package.json
+++ b/package/zerobias/c_commsvc/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_commsvc",
+  "version": "1.0.0-rc.1",
+  "description": "Telecommunications and managed communications services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/c_commsvc/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.c_commsvc.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-d_svc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/c_crypto/.npmrc
+++ b/package/zerobias/c_crypto/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/c_crypto/build.gradle.kts
+++ b/package/zerobias/c_crypto/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/c_crypto/gate-stamp.json
+++ b/package/zerobias/c_crypto/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l1-categories",
+  "sourceHash": "e3aa1f8399063ce309eeca849165bf386596e9191d9b54b9eaac40fbd30b5dc4",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/c_crypto/index.yml
+++ b/package/zerobias/c_crypto/index.yml
@@ -1,0 +1,12 @@
+id: c0a361d0-0c6e-451d-88ac-182afc62386c
+name: Cryptography and Key Management
+description: Encryption, key management, and PKI services.
+segmentType: category
+imageUrl: https://cdn.auditmation.io/logos/zerobias-c_crypto-segment.svg
+code: c_crypto
+externalId: Cryptography and Key Management
+status: published
+parents:
+  - d_svc
+tags: []
+aliases: []

--- a/package/zerobias/c_crypto/package.json
+++ b/package/zerobias/c_crypto/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_crypto",
+  "version": "1.0.0-rc.1",
+  "description": "Encryption, key management, and PKI services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/c_crypto/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.c_crypto.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-d_svc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/c_dataprivacy/.npmrc
+++ b/package/zerobias/c_dataprivacy/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/c_dataprivacy/build.gradle.kts
+++ b/package/zerobias/c_dataprivacy/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/c_dataprivacy/gate-stamp.json
+++ b/package/zerobias/c_dataprivacy/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l1-categories",
+  "sourceHash": "bc53b2d1646c1bde05e6bd4803b8fe3cfd852894e7f0730a296b1252ae6c8185",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/c_dataprivacy/index.yml
+++ b/package/zerobias/c_dataprivacy/index.yml
@@ -1,0 +1,12 @@
+id: e7765948-0afd-4981-abea-719a02bb5566
+name: Data Protection and Privacy
+description: Data protection, privacy, and loss-prevention services.
+segmentType: category
+imageUrl: https://cdn.auditmation.io/logos/zerobias-c_dataprivacy-segment.svg
+code: c_dataprivacy
+externalId: Data Protection and Privacy
+status: published
+parents:
+  - d_svc
+tags: []
+aliases: []

--- a/package/zerobias/c_dataprivacy/package.json
+++ b/package/zerobias/c_dataprivacy/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_dataprivacy",
+  "version": "1.0.0-rc.1",
+  "description": "Data protection, privacy, and loss-prevention services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/c_dataprivacy/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.c_dataprivacy.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-d_svc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/c_ehs/.npmrc
+++ b/package/zerobias/c_ehs/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/c_ehs/build.gradle.kts
+++ b/package/zerobias/c_ehs/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/c_ehs/gate-stamp.json
+++ b/package/zerobias/c_ehs/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l1-categories",
+  "sourceHash": "9cd487c5b919983c83b9e784902d819d6e7d5192f0815e53e445620271df1d64",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/c_ehs/index.yml
+++ b/package/zerobias/c_ehs/index.yml
@@ -1,0 +1,12 @@
+id: 0ec08ade-722f-4877-9cd6-9e0a87d246aa
+name: Environmental, Health and Safety
+description: Environmental, occupational safety, and ESG services.
+segmentType: category
+imageUrl: https://cdn.auditmation.io/logos/zerobias-c_ehs-segment.svg
+code: c_ehs
+externalId: Environmental, Health and Safety
+status: published
+parents:
+  - d_svc
+tags: []
+aliases: []

--- a/package/zerobias/c_ehs/package.json
+++ b/package/zerobias/c_ehs/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_ehs",
+  "version": "1.0.0-rc.1",
+  "description": "Environmental, occupational safety, and ESG services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/c_ehs/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.c_ehs.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-d_svc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/c_endpoint/.npmrc
+++ b/package/zerobias/c_endpoint/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/c_endpoint/build.gradle.kts
+++ b/package/zerobias/c_endpoint/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/c_endpoint/gate-stamp.json
+++ b/package/zerobias/c_endpoint/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l1-categories",
+  "sourceHash": "1148985c7f39aa4faba29ddcfa75bb4be1853c23478ca73334a4a0d0b3d97cd2",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/c_endpoint/index.yml
+++ b/package/zerobias/c_endpoint/index.yml
@@ -1,0 +1,12 @@
+id: 6651c613-1a6e-4585-97e7-d064bec432bc
+name: Endpoint and Device Security
+description: Endpoint detection, response, and device security services.
+segmentType: category
+imageUrl: https://cdn.auditmation.io/logos/zerobias-c_endpoint-segment.svg
+code: c_endpoint
+externalId: Endpoint and Device Security
+status: published
+parents:
+  - d_svc
+tags: []
+aliases: []

--- a/package/zerobias/c_endpoint/package.json
+++ b/package/zerobias/c_endpoint/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_endpoint",
+  "version": "1.0.0-rc.1",
+  "description": "Endpoint detection, response, and device security services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/c_endpoint/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.c_endpoint.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-d_svc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/c_fincrime/.npmrc
+++ b/package/zerobias/c_fincrime/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/c_fincrime/build.gradle.kts
+++ b/package/zerobias/c_fincrime/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/c_fincrime/gate-stamp.json
+++ b/package/zerobias/c_fincrime/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l1-categories",
+  "sourceHash": "170f4d348d536bd6ffe7008f3c08a23d8921aca28364ae37d1b8ffab206bf3f6",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/c_fincrime/index.yml
+++ b/package/zerobias/c_fincrime/index.yml
@@ -1,0 +1,12 @@
+id: d457568f-f1d0-4917-8666-42b023f0a6b4
+name: Financial Crime Compliance
+description: KYC, AML, and sanctions compliance services.
+segmentType: category
+imageUrl: https://cdn.auditmation.io/logos/zerobias-c_fincrime-segment.svg
+code: c_fincrime
+externalId: Financial Crime Compliance
+status: published
+parents:
+  - d_svc
+tags: []
+aliases: []

--- a/package/zerobias/c_fincrime/package.json
+++ b/package/zerobias/c_fincrime/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_fincrime",
+  "version": "1.0.0-rc.1",
+  "description": "KYC, AML, and sanctions compliance services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/c_fincrime/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.c_fincrime.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-d_svc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/c_grc/.npmrc
+++ b/package/zerobias/c_grc/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/c_grc/build.gradle.kts
+++ b/package/zerobias/c_grc/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/c_grc/gate-stamp.json
+++ b/package/zerobias/c_grc/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l1-categories",
+  "sourceHash": "704d51789063d0c3e9f026c4e7f9ba58d317e00825db752f93784ad42f1a209d",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/c_grc/index.yml
+++ b/package/zerobias/c_grc/index.yml
@@ -1,0 +1,12 @@
+id: 2f04935a-1d4b-45d9-8228-4ebb5ee09d1b
+name: Governance, Risk and Compliance
+description: Governance, risk management, and compliance advisory services.
+segmentType: category
+imageUrl: https://cdn.auditmation.io/logos/zerobias-c_grc-segment.svg
+code: c_grc
+externalId: Governance, Risk and Compliance
+status: published
+parents:
+  - d_svc
+tags: []
+aliases: []

--- a/package/zerobias/c_grc/package.json
+++ b/package/zerobias/c_grc/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_grc",
+  "version": "1.0.0-rc.1",
+  "description": "Governance, risk management, and compliance advisory services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/c_grc/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.c_grc.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-d_svc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/c_hr/.npmrc
+++ b/package/zerobias/c_hr/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/c_hr/build.gradle.kts
+++ b/package/zerobias/c_hr/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/c_hr/gate-stamp.json
+++ b/package/zerobias/c_hr/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l1-categories",
+  "sourceHash": "3921d1eb12c7967dae2d271c145cfc5b36b247973aa35635d376b20e8dd43f3f",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/c_hr/index.yml
+++ b/package/zerobias/c_hr/index.yml
@@ -1,0 +1,12 @@
+id: a8ea3275-4509-4a34-add9-d66b94f2239c
+name: Human Resources
+description: Staffing, recruiting, and human resources services.
+segmentType: category
+imageUrl: https://cdn.auditmation.io/logos/zerobias-c_hr-segment.svg
+code: c_hr
+externalId: Human Resources
+status: published
+parents:
+  - d_svc
+tags: []
+aliases: []

--- a/package/zerobias/c_hr/package.json
+++ b/package/zerobias/c_hr/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_hr",
+  "version": "1.0.0-rc.1",
+  "description": "Staffing, recruiting, and human resources services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/c_hr/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.c_hr.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-d_svc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/c_idam/.npmrc
+++ b/package/zerobias/c_idam/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/c_idam/build.gradle.kts
+++ b/package/zerobias/c_idam/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/c_idam/gate-stamp.json
+++ b/package/zerobias/c_idam/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l1-categories",
+  "sourceHash": "f170de62cd9179791c35a17f189bac585f27ccf74722da2ac14270258859b023",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/c_idam/index.yml
+++ b/package/zerobias/c_idam/index.yml
@@ -1,0 +1,12 @@
+id: 58ff442b-e82a-4fe2-bc9b-f87588f1b172
+name: Identity and Access
+description: Identity and access management services.
+segmentType: category
+imageUrl: https://cdn.auditmation.io/logos/zerobias-c_idam-segment.svg
+code: c_idam
+externalId: Identity and Access
+status: published
+parents:
+  - d_svc
+tags: []
+aliases: []

--- a/package/zerobias/c_idam/package.json
+++ b/package/zerobias/c_idam/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_idam",
+  "version": "1.0.0-rc.1",
+  "description": "Identity and access management services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/c_idam/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.c_idam.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-d_svc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/c_insurance/.npmrc
+++ b/package/zerobias/c_insurance/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/c_insurance/build.gradle.kts
+++ b/package/zerobias/c_insurance/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/c_insurance/gate-stamp.json
+++ b/package/zerobias/c_insurance/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l1-categories",
+  "sourceHash": "cbe1f95e0755580af26015b3229b283440d2f6da617a0f16d3aa3e2fe1490786",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/c_insurance/index.yml
+++ b/package/zerobias/c_insurance/index.yml
@@ -1,0 +1,12 @@
+id: 3faff6f3-9cdf-492c-9c36-0a27f97919c6
+name: Insurance and Bonding
+description: Insurance advisory, surety, and bonding services.
+segmentType: category
+imageUrl: https://cdn.auditmation.io/logos/zerobias-c_insurance-segment.svg
+code: c_insurance
+externalId: Insurance and Bonding
+status: published
+parents:
+  - d_svc
+tags: []
+aliases: []

--- a/package/zerobias/c_insurance/package.json
+++ b/package/zerobias/c_insurance/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_insurance",
+  "version": "1.0.0-rc.1",
+  "description": "Insurance advisory, surety, and bonding services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/c_insurance/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.c_insurance.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-d_svc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/c_ir/.npmrc
+++ b/package/zerobias/c_ir/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/c_ir/build.gradle.kts
+++ b/package/zerobias/c_ir/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/c_ir/gate-stamp.json
+++ b/package/zerobias/c_ir/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l1-categories",
+  "sourceHash": "1efcd345555eb439509c864b1f155ec2e15bbf0e427cab132ed77fb9aa8f20cc",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/c_ir/index.yml
+++ b/package/zerobias/c_ir/index.yml
@@ -1,0 +1,12 @@
+id: 1acacc9d-d8aa-4ead-8c52-51e23853a198
+name: Incident Response and Forensics
+description: Incident response, digital forensics, and breach recovery services.
+segmentType: category
+imageUrl: https://cdn.auditmation.io/logos/zerobias-c_ir-segment.svg
+code: c_ir
+externalId: Incident Response and Forensics
+status: published
+parents:
+  - d_svc
+tags: []
+aliases: []

--- a/package/zerobias/c_ir/package.json
+++ b/package/zerobias/c_ir/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_ir",
+  "version": "1.0.0-rc.1",
+  "description": "Incident response, digital forensics, and breach recovery services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/c_ir/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.c_ir.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-d_svc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/c_itops/.npmrc
+++ b/package/zerobias/c_itops/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/c_itops/build.gradle.kts
+++ b/package/zerobias/c_itops/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/c_itops/gate-stamp.json
+++ b/package/zerobias/c_itops/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l1-categories",
+  "sourceHash": "0c9e44feca737d1f6480bfc2d3e679ce0c0baabc0eb05eff7f26b14d774ae704",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/c_itops/index.yml
+++ b/package/zerobias/c_itops/index.yml
@@ -1,0 +1,12 @@
+id: cbf47aa0-3aca-4834-90d5-0f50aa895237
+name: IT Operations
+description: Managed IT operations and end-user support services.
+segmentType: category
+imageUrl: https://cdn.auditmation.io/logos/zerobias-c_itops-segment.svg
+code: c_itops
+externalId: IT Operations
+status: published
+parents:
+  - d_svc
+tags: []
+aliases: []

--- a/package/zerobias/c_itops/package.json
+++ b/package/zerobias/c_itops/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_itops",
+  "version": "1.0.0-rc.1",
+  "description": "Managed IT operations and end-user support services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/c_itops/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.c_itops.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-d_svc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/c_labor/.npmrc
+++ b/package/zerobias/c_labor/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/c_labor/build.gradle.kts
+++ b/package/zerobias/c_labor/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/c_labor/gate-stamp.json
+++ b/package/zerobias/c_labor/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l1-categories",
+  "sourceHash": "c17ad7835f12dc910ce0f2298fb612b6b2a28f72edd12fae3c8d2d3f5524a9c3",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/c_labor/index.yml
+++ b/package/zerobias/c_labor/index.yml
@@ -1,0 +1,12 @@
+id: 87dc303e-f01a-40d6-9a4d-e1c9a994928a
+name: Employment and Labor Compliance
+description: Employment, labor, and immigration compliance services.
+segmentType: category
+imageUrl: https://cdn.auditmation.io/logos/zerobias-c_labor-segment.svg
+code: c_labor
+externalId: Employment and Labor Compliance
+status: published
+parents:
+  - d_svc
+tags: []
+aliases: []

--- a/package/zerobias/c_labor/package.json
+++ b/package/zerobias/c_labor/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_labor",
+  "version": "1.0.0-rc.1",
+  "description": "Employment, labor, and immigration compliance services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/c_labor/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.c_labor.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-d_svc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/c_legal/.npmrc
+++ b/package/zerobias/c_legal/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/c_legal/build.gradle.kts
+++ b/package/zerobias/c_legal/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/c_legal/gate-stamp.json
+++ b/package/zerobias/c_legal/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l1-categories",
+  "sourceHash": "66e5333aae2205effb38d0353ebbd300efd4ff3d2cfd4b6142b3d66aa53c8950",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/c_legal/index.yml
+++ b/package/zerobias/c_legal/index.yml
@@ -1,0 +1,12 @@
+id: 79fb747b-619d-484c-b1d9-77ab558feba5
+name: Legal and Regulatory
+description: Legal, regulatory, and compliance counsel services.
+segmentType: category
+imageUrl: https://cdn.auditmation.io/logos/zerobias-c_legal-segment.svg
+code: c_legal
+externalId: Legal and Regulatory
+status: published
+parents:
+  - d_svc
+tags: []
+aliases: []

--- a/package/zerobias/c_legal/package.json
+++ b/package/zerobias/c_legal/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_legal",
+  "version": "1.0.0-rc.1",
+  "description": "Legal, regulatory, and compliance counsel services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/c_legal/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.c_legal.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-d_svc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/c_netsec/.npmrc
+++ b/package/zerobias/c_netsec/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/c_netsec/build.gradle.kts
+++ b/package/zerobias/c_netsec/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/c_netsec/gate-stamp.json
+++ b/package/zerobias/c_netsec/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l1-categories",
+  "sourceHash": "935cb3b1762ba2febfa96e880ed25958c1daf5710f66cf2297aafa2be458a586",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/c_netsec/index.yml
+++ b/package/zerobias/c_netsec/index.yml
@@ -1,0 +1,12 @@
+id: 98db93ac-9494-4de7-8c1e-31a7621b423c
+name: Network Security
+description: Network security management and protection services.
+segmentType: category
+imageUrl: https://cdn.auditmation.io/logos/zerobias-c_netsec-segment.svg
+code: c_netsec
+externalId: Network Security
+status: published
+parents:
+  - d_svc
+tags: []
+aliases: []

--- a/package/zerobias/c_netsec/package.json
+++ b/package/zerobias/c_netsec/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_netsec",
+  "version": "1.0.0-rc.1",
+  "description": "Network security management and protection services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/c_netsec/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.c_netsec.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-d_svc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/c_notary/.npmrc
+++ b/package/zerobias/c_notary/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/c_notary/build.gradle.kts
+++ b/package/zerobias/c_notary/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/c_notary/gate-stamp.json
+++ b/package/zerobias/c_notary/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l1-categories",
+  "sourceHash": "4c56b8a6534b896d266fa28603f2595b0896be2dc7d44a0ccd056b0ffe21fbff",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/c_notary/index.yml
+++ b/package/zerobias/c_notary/index.yml
@@ -1,0 +1,12 @@
+id: 4081a9b0-28d1-4c4b-a2e1-9ce2e4da5dc8
+name: Notary and Document Authentication
+description: Notarization and document authentication services.
+segmentType: category
+imageUrl: https://cdn.auditmation.io/logos/zerobias-c_notary-segment.svg
+code: c_notary
+externalId: Notary and Document Authentication
+status: published
+parents:
+  - d_svc
+tags: []
+aliases: []

--- a/package/zerobias/c_notary/package.json
+++ b/package/zerobias/c_notary/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_notary",
+  "version": "1.0.0-rc.1",
+  "description": "Notarization and document authentication services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/c_notary/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.c_notary.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-d_svc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/c_otsec/.npmrc
+++ b/package/zerobias/c_otsec/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/c_otsec/build.gradle.kts
+++ b/package/zerobias/c_otsec/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/c_otsec/gate-stamp.json
+++ b/package/zerobias/c_otsec/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l1-categories",
+  "sourceHash": "7c255c4f0cc1c71245a9aa93ee286ade16daa8e558bd1b621e8d904431e27603",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/c_otsec/index.yml
+++ b/package/zerobias/c_otsec/index.yml
@@ -1,0 +1,12 @@
+id: 949ff01a-b201-4d30-879a-8aad46502c3d
+name: OT and IoT Security
+description: Operational technology and IoT security services.
+segmentType: category
+imageUrl: https://cdn.auditmation.io/logos/zerobias-c_otsec-segment.svg
+code: c_otsec
+externalId: OT and IoT Security
+status: published
+parents:
+  - d_svc
+tags: []
+aliases: []

--- a/package/zerobias/c_otsec/package.json
+++ b/package/zerobias/c_otsec/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_otsec",
+  "version": "1.0.0-rc.1",
+  "description": "Operational technology and IoT security services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/c_otsec/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.c_otsec.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-d_svc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/c_physical/.npmrc
+++ b/package/zerobias/c_physical/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/c_physical/build.gradle.kts
+++ b/package/zerobias/c_physical/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/c_physical/gate-stamp.json
+++ b/package/zerobias/c_physical/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l1-categories",
+  "sourceHash": "a44ff346886c0b305ae518514e99bdadacc50be52ecfeea3eac9baaeb9e11d2a",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/c_physical/index.yml
+++ b/package/zerobias/c_physical/index.yml
@@ -1,0 +1,12 @@
+id: 3167a110-02bb-4a50-adf1-d99ec0a6324c
+name: Physical and Environmental Security
+description: Physical security, facility access, and environmental controls services.
+segmentType: category
+imageUrl: https://cdn.auditmation.io/logos/zerobias-c_physical-segment.svg
+code: c_physical
+externalId: Physical and Environmental Security
+status: published
+parents:
+  - d_svc
+tags: []
+aliases: []

--- a/package/zerobias/c_physical/package.json
+++ b/package/zerobias/c_physical/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_physical",
+  "version": "1.0.0-rc.1",
+  "description": "Physical security, facility access, and environmental controls services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/c_physical/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.c_physical.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-d_svc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/c_pmo/.npmrc
+++ b/package/zerobias/c_pmo/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/c_pmo/build.gradle.kts
+++ b/package/zerobias/c_pmo/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/c_pmo/gate-stamp.json
+++ b/package/zerobias/c_pmo/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l1-categories",
+  "sourceHash": "618b66049fc553d9b5555cd03a5f258079fbb80282dd507164e919477fcc3b50",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/c_pmo/index.yml
+++ b/package/zerobias/c_pmo/index.yml
@@ -1,0 +1,12 @@
+id: 7eb9a477-0fae-4228-857c-4e51ab9c5fb6
+name: Project and Program Management
+description: Project and program management services.
+segmentType: category
+imageUrl: https://cdn.auditmation.io/logos/zerobias-c_pmo-segment.svg
+code: c_pmo
+externalId: Project and Program Management
+status: published
+parents:
+  - d_svc
+tags: []
+aliases: []

--- a/package/zerobias/c_pmo/package.json
+++ b/package/zerobias/c_pmo/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_pmo",
+  "version": "1.0.0-rc.1",
+  "description": "Project and program management services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/c_pmo/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.c_pmo.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-d_svc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/c_procurement/.npmrc
+++ b/package/zerobias/c_procurement/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/c_procurement/build.gradle.kts
+++ b/package/zerobias/c_procurement/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/c_procurement/gate-stamp.json
+++ b/package/zerobias/c_procurement/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l1-categories",
+  "sourceHash": "7de22bc7530ce62bd4594c15a8854fd00e19317dcb5f292a6090af9498b4b5f0",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/c_procurement/index.yml
+++ b/package/zerobias/c_procurement/index.yml
@@ -1,0 +1,12 @@
+id: 6aa63a8b-279a-4b2d-b793-496189e1ac4e
+name: Proposals and Procurement
+description: Proposal, grant writing, and procurement support services.
+segmentType: category
+imageUrl: https://cdn.auditmation.io/logos/zerobias-c_procurement-segment.svg
+code: c_procurement
+externalId: Proposals and Procurement
+status: published
+parents:
+  - d_svc
+tags: []
+aliases: []

--- a/package/zerobias/c_procurement/package.json
+++ b/package/zerobias/c_procurement/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_procurement",
+  "version": "1.0.0-rc.1",
+  "description": "Proposal, grant writing, and procurement support services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/c_procurement/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.c_procurement.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-d_svc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/c_regapproval/.npmrc
+++ b/package/zerobias/c_regapproval/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/c_regapproval/build.gradle.kts
+++ b/package/zerobias/c_regapproval/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/c_regapproval/gate-stamp.json
+++ b/package/zerobias/c_regapproval/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l1-categories",
+  "sourceHash": "12c41282b187c4d9303fbcabd990b8e92da706dd2728016b7eb21b3fa78f1e70",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/c_regapproval/index.yml
+++ b/package/zerobias/c_regapproval/index.yml
@@ -1,0 +1,12 @@
+id: 4d521f20-a56b-4925-832f-5d7afe9d4f43
+name: Regulatory Approvals and Licensing
+description: Regulatory approval, licensing, and product certification services.
+segmentType: category
+imageUrl: https://cdn.auditmation.io/logos/zerobias-c_regapproval-segment.svg
+code: c_regapproval
+externalId: Regulatory Approvals and Licensing
+status: published
+parents:
+  - d_svc
+tags: []
+aliases: []

--- a/package/zerobias/c_regapproval/package.json
+++ b/package/zerobias/c_regapproval/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_regapproval",
+  "version": "1.0.0-rc.1",
+  "description": "Regulatory approval, licensing, and product certification services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/c_regapproval/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.c_regapproval.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-d_svc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/c_resilience/.npmrc
+++ b/package/zerobias/c_resilience/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/c_resilience/build.gradle.kts
+++ b/package/zerobias/c_resilience/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/c_resilience/gate-stamp.json
+++ b/package/zerobias/c_resilience/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l1-categories",
+  "sourceHash": "9904cb27ad7b8ed5ba8e262a147f80b6288432e03224dd53937466874482b6f9",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/c_resilience/index.yml
+++ b/package/zerobias/c_resilience/index.yml
@@ -1,0 +1,12 @@
+id: 88fdf71f-fa57-433c-a861-69f17efdd1a9
+name: Business Resilience
+description: Backup, disaster recovery, and business continuity services.
+segmentType: category
+imageUrl: https://cdn.auditmation.io/logos/zerobias-c_resilience-segment.svg
+code: c_resilience
+externalId: Business Resilience
+status: published
+parents:
+  - d_svc
+tags: []
+aliases: []

--- a/package/zerobias/c_resilience/package.json
+++ b/package/zerobias/c_resilience/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_resilience",
+  "version": "1.0.0-rc.1",
+  "description": "Backup, disaster recovery, and business continuity services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/c_resilience/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.c_resilience.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-d_svc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/c_screening/.npmrc
+++ b/package/zerobias/c_screening/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/c_screening/build.gradle.kts
+++ b/package/zerobias/c_screening/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/c_screening/gate-stamp.json
+++ b/package/zerobias/c_screening/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l1-categories",
+  "sourceHash": "bf8c5ac80df1e55179de621e8c193c3c79563289a8b1b459e0c83fd3c9c537fd",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/c_screening/index.yml
+++ b/package/zerobias/c_screening/index.yml
@@ -1,0 +1,12 @@
+id: f1ea4da6-9da5-4c33-ada7-59853c9c39f7
+name: Background and Screening
+description: Background checks, identity verification, and due diligence services.
+segmentType: category
+imageUrl: https://cdn.auditmation.io/logos/zerobias-c_screening-segment.svg
+code: c_screening
+externalId: Background and Screening
+status: published
+parents:
+  - d_svc
+tags: []
+aliases: []

--- a/package/zerobias/c_screening/package.json
+++ b/package/zerobias/c_screening/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_screening",
+  "version": "1.0.0-rc.1",
+  "description": "Background checks, identity verification, and due diligence services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/c_screening/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.c_screening.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-d_svc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/c_secasmt/.npmrc
+++ b/package/zerobias/c_secasmt/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/c_secasmt/build.gradle.kts
+++ b/package/zerobias/c_secasmt/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/c_secasmt/gate-stamp.json
+++ b/package/zerobias/c_secasmt/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l1-categories",
+  "sourceHash": "696b5238b744d98a116c376eb50613e143fa30b6c4d17f0bfb3aa27513767d8a",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/c_secasmt/index.yml
+++ b/package/zerobias/c_secasmt/index.yml
@@ -1,0 +1,12 @@
+id: a65940d6-4353-4b3f-bb88-8dcb04637b01
+name: Security Testing and Assessment
+description: Offensive and evaluative security testing and assessment services.
+segmentType: category
+imageUrl: https://cdn.auditmation.io/logos/zerobias-c_secasmt-segment.svg
+code: c_secasmt
+externalId: Security Testing and Assessment
+status: published
+parents:
+  - d_svc
+tags: []
+aliases: []

--- a/package/zerobias/c_secasmt/package.json
+++ b/package/zerobias/c_secasmt/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_secasmt",
+  "version": "1.0.0-rc.1",
+  "description": "Offensive and evaluative security testing and assessment services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/c_secasmt/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.c_secasmt.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-d_svc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/c_secops/.npmrc
+++ b/package/zerobias/c_secops/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/c_secops/build.gradle.kts
+++ b/package/zerobias/c_secops/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/c_secops/gate-stamp.json
+++ b/package/zerobias/c_secops/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l1-categories",
+  "sourceHash": "91eb0d2bb47fb28332805f92ea1a411505ad226b0fad8af23428224c0c03a68a",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/c_secops/index.yml
+++ b/package/zerobias/c_secops/index.yml
@@ -1,0 +1,12 @@
+id: 31ba90f1-29a1-430f-a55a-f62d442c8f68
+name: Security Operations
+description: Managed security monitoring, detection, and operations services.
+segmentType: category
+imageUrl: https://cdn.auditmation.io/logos/zerobias-c_secops-segment.svg
+code: c_secops
+externalId: Security Operations
+status: published
+parents:
+  - d_svc
+tags: []
+aliases: []

--- a/package/zerobias/c_secops/package.json
+++ b/package/zerobias/c_secops/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_secops",
+  "version": "1.0.0-rc.1",
+  "description": "Managed security monitoring, detection, and operations services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/c_secops/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.c_secops.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-d_svc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/c_swdev/.npmrc
+++ b/package/zerobias/c_swdev/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/c_swdev/build.gradle.kts
+++ b/package/zerobias/c_swdev/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/c_swdev/gate-stamp.json
+++ b/package/zerobias/c_swdev/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l1-categories",
+  "sourceHash": "26f64b2fc96fe3490bef9e431c43a86b7ea79b95faf831a73a38ce3589840b35",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/c_swdev/index.yml
+++ b/package/zerobias/c_swdev/index.yml
@@ -1,0 +1,12 @@
+id: 7828c010-a239-456e-9a98-f410dab48263
+name: Software Development
+description: Custom software, application, and data engineering services.
+segmentType: category
+imageUrl: https://cdn.auditmation.io/logos/zerobias-c_swdev-segment.svg
+code: c_swdev
+externalId: Software Development
+status: published
+parents:
+  - d_svc
+tags: []
+aliases: []

--- a/package/zerobias/c_swdev/package.json
+++ b/package/zerobias/c_swdev/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_swdev",
+  "version": "1.0.0-rc.1",
+  "description": "Custom software, application, and data engineering services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/c_swdev/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.c_swdev.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-d_svc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/c_tax/.npmrc
+++ b/package/zerobias/c_tax/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/c_tax/build.gradle.kts
+++ b/package/zerobias/c_tax/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/c_tax/gate-stamp.json
+++ b/package/zerobias/c_tax/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l1-categories",
+  "sourceHash": "f6373298ee5b5a8b3b44e05b41ea156bfe7315338e7d615fda5a630217058472",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/c_tax/index.yml
+++ b/package/zerobias/c_tax/index.yml
@@ -1,0 +1,12 @@
+id: c1cb8e0e-7d64-4874-982a-4afbdbfbaad7
+name: Tax and Accounting
+description: Tax, accounting, bookkeeping, and financial audit services.
+segmentType: category
+imageUrl: https://cdn.auditmation.io/logos/zerobias-c_tax-segment.svg
+code: c_tax
+externalId: Tax and Accounting
+status: published
+parents:
+  - d_svc
+tags: []
+aliases: []

--- a/package/zerobias/c_tax/package.json
+++ b/package/zerobias/c_tax/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_tax",
+  "version": "1.0.0-rc.1",
+  "description": "Tax, accounting, bookkeeping, and financial audit services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/c_tax/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.c_tax.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-d_svc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/c_train/.npmrc
+++ b/package/zerobias/c_train/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/c_train/build.gradle.kts
+++ b/package/zerobias/c_train/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/c_train/gate-stamp.json
+++ b/package/zerobias/c_train/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l1-categories",
+  "sourceHash": "a96ce5d43a55ea24c156b74e6356a05b674210074c89d3fc2115ba6b22c5d5aa",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/c_train/index.yml
+++ b/package/zerobias/c_train/index.yml
@@ -1,0 +1,12 @@
+id: 73eca602-a66e-48c8-861c-ab4e890e74eb
+name: Training and Education
+description: Security awareness and technical training services.
+segmentType: category
+imageUrl: https://cdn.auditmation.io/logos/zerobias-c_train-segment.svg
+code: c_train
+externalId: Training and Education
+status: published
+parents:
+  - d_svc
+tags: []
+aliases: []

--- a/package/zerobias/c_train/package.json
+++ b/package/zerobias/c_train/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_train",
+  "version": "1.0.0-rc.1",
+  "description": "Security awareness and technical training services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/c_train/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.c_train.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-d_svc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/c_validation/.npmrc
+++ b/package/zerobias/c_validation/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/c_validation/build.gradle.kts
+++ b/package/zerobias/c_validation/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/c_validation/gate-stamp.json
+++ b/package/zerobias/c_validation/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l1-categories",
+  "sourceHash": "ce443dbb4bdd10aa423f91a92c8b4d5124e300596696c18a3360dc682ea33213",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/c_validation/index.yml
+++ b/package/zerobias/c_validation/index.yml
@@ -1,0 +1,12 @@
+id: 915c0783-f4e0-4077-b12c-f726504d78c2
+name: Validation and Certification
+description: Product validation, independent verification, and certification services.
+segmentType: category
+imageUrl: https://cdn.auditmation.io/logos/zerobias-c_validation-segment.svg
+code: c_validation
+externalId: Validation and Certification
+status: published
+parents:
+  - d_svc
+tags: []
+aliases: []

--- a/package/zerobias/c_validation/package.json
+++ b/package/zerobias/c_validation/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-c_validation",
+  "version": "1.0.0-rc.1",
+  "description": "Product validation, independent verification, and certification services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/c_validation/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.c_validation.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-d_svc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}


### PR DESCRIPTION
Level 1 of the Services taxonomy: the 37 service categories under the d_svc domain (published as #28, d_svc@1.0.0).

Per Chris (no inside-dep publishing - parents publish before children): d_svc landed first, so each category here resolves segment-zerobias-d_svc@latest.

All 37 gated GREEN (slot-less, remote dataloader-service); each ships its gate-stamp.json (publish preflight requires it), with 37 distinct sourceHashes. The 131 service segments (L2, s_*) follow once these categories publish.

@danielrojas-nf - L1 of the level-by-level rollout, ready to merge when you are.