### PR TITLE
feat(services): add 131 service segments (s_*) - L2 of 3 (final)

### DIFF
--- a/package/zerobias/s_a11yaudit/.npmrc
+++ b/package/zerobias/s_a11yaudit/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_a11yaudit/build.gradle.kts
+++ b/package/zerobias/s_a11yaudit/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_a11yaudit/gate-stamp.json
+++ b/package/zerobias/s_a11yaudit/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "fa3eb69bcf653d93f0d58485ce1b9eba1a03f96e61ee40622373cc31172e2024",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_a11yaudit/index.yml
+++ b/package/zerobias/s_a11yaudit/index.yml
@@ -1,0 +1,12 @@
+id: 271b2f74-1582-498e-a940-1574ce957bd8
+name: Accessibility Auditing
+description: Accessibility auditing services (ADA, Section 508, WCAG).
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_a11yaudit-segment.svg
+code: s_a11yaudit
+externalId: Accessibility Auditing
+status: published
+parents:
+  - c_accessibility
+tags: []
+aliases: []

--- a/package/zerobias/s_a11yaudit/package.json
+++ b/package/zerobias/s_a11yaudit/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_a11yaudit",
+  "version": "1.0.0-rc.1",
+  "description": "Accessibility auditing services (ADA, Section 508, WCAG).",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_a11yaudit/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_a11yaudit.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_accessibility": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_a11yremediation/.npmrc
+++ b/package/zerobias/s_a11yremediation/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_a11yremediation/build.gradle.kts
+++ b/package/zerobias/s_a11yremediation/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_a11yremediation/gate-stamp.json
+++ b/package/zerobias/s_a11yremediation/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "5578a8496c796aa6e2c86ceb8793191f077edb61c2e3c62a95c11869780a5c03",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_a11yremediation/index.yml
+++ b/package/zerobias/s_a11yremediation/index.yml
@@ -1,0 +1,12 @@
+id: d1155a47-902d-415e-ae20-efa2e1fab1e2
+name: Accessibility Remediation
+description: Accessibility remediation services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_a11yremediation-segment.svg
+code: s_a11yremediation
+externalId: Accessibility Remediation
+status: published
+parents:
+  - c_accessibility
+tags: []
+aliases: []

--- a/package/zerobias/s_a11yremediation/package.json
+++ b/package/zerobias/s_a11yremediation/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_a11yremediation",
+  "version": "1.0.0-rc.1",
+  "description": "Accessibility remediation services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_a11yremediation/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_a11yremediation.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_accessibility": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_accreditation/.npmrc
+++ b/package/zerobias/s_accreditation/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_accreditation/build.gradle.kts
+++ b/package/zerobias/s_accreditation/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_accreditation/gate-stamp.json
+++ b/package/zerobias/s_accreditation/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "76317784a4b96e2c5d932b42802499aa830aadf576f8998460530da49c307fcd",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_accreditation/index.yml
+++ b/package/zerobias/s_accreditation/index.yml
@@ -1,0 +1,12 @@
+id: 243c05b6-4121-4b0a-be0d-3a2cd6aaf682
+name: Accreditation and Certification
+description: Accreditation and certification body services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_accreditation-segment.svg
+code: s_accreditation
+externalId: Accreditation and Certification
+status: published
+parents:
+  - c_validation
+tags: []
+aliases: []

--- a/package/zerobias/s_accreditation/package.json
+++ b/package/zerobias/s_accreditation/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_accreditation",
+  "version": "1.0.0-rc.1",
+  "description": "Accreditation and certification body services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_accreditation/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_accreditation.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_validation": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_aigov/.npmrc
+++ b/package/zerobias/s_aigov/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_aigov/build.gradle.kts
+++ b/package/zerobias/s_aigov/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_aigov/gate-stamp.json
+++ b/package/zerobias/s_aigov/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "5394d98d8789035adfa3becabd0462d1b254a4002cc75121d8a2f5573b32917a",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_aigov/index.yml
+++ b/package/zerobias/s_aigov/index.yml
@@ -1,0 +1,12 @@
+id: f5ceb37f-bb27-46b2-b194-a7fd153b6dac
+name: AI Governance
+description: Artificial intelligence governance and risk services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_aigov-segment.svg
+code: s_aigov
+externalId: AI Governance
+status: published
+parents:
+  - c_ai
+tags: []
+aliases: []

--- a/package/zerobias/s_aigov/package.json
+++ b/package/zerobias/s_aigov/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_aigov",
+  "version": "1.0.0-rc.1",
+  "description": "Artificial intelligence governance and risk services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_aigov/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_aigov.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_ai": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_aisec/.npmrc
+++ b/package/zerobias/s_aisec/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_aisec/build.gradle.kts
+++ b/package/zerobias/s_aisec/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_aisec/gate-stamp.json
+++ b/package/zerobias/s_aisec/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "74231809a27168e81daf66b0e9e84208bf47bb6139b90d40514abc56b9609252",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_aisec/index.yml
+++ b/package/zerobias/s_aisec/index.yml
@@ -1,0 +1,12 @@
+id: 88348b97-7e29-4231-854e-7db6d53aa37c
+name: AI and ML Security
+description: AI and machine learning security services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_aisec-segment.svg
+code: s_aisec
+externalId: AI and ML Security
+status: published
+parents:
+  - c_ai
+tags: []
+aliases: []

--- a/package/zerobias/s_aisec/package.json
+++ b/package/zerobias/s_aisec/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_aisec",
+  "version": "1.0.0-rc.1",
+  "description": "AI and machine learning security services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_aisec/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_aisec.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_ai": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_aml/.npmrc
+++ b/package/zerobias/s_aml/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_aml/build.gradle.kts
+++ b/package/zerobias/s_aml/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_aml/gate-stamp.json
+++ b/package/zerobias/s_aml/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "5de89f00ae1f1dad02b2d490eadd2e020725563b7b551d7a8d54281cc609371b",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_aml/index.yml
+++ b/package/zerobias/s_aml/index.yml
@@ -1,0 +1,12 @@
+id: 27fa3899-199d-4980-acca-fcd195c4cc92
+name: AML and BSA Compliance
+description: Anti-money-laundering and BSA compliance services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_aml-segment.svg
+code: s_aml
+externalId: AML and BSA Compliance
+status: published
+parents:
+  - c_fincrime
+tags: []
+aliases: []

--- a/package/zerobias/s_aml/package.json
+++ b/package/zerobias/s_aml/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_aml",
+  "version": "1.0.0-rc.1",
+  "description": "Anti-money-laundering and BSA compliance services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_aml/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_aml.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_fincrime": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_apidev/.npmrc
+++ b/package/zerobias/s_apidev/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_apidev/build.gradle.kts
+++ b/package/zerobias/s_apidev/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_apidev/gate-stamp.json
+++ b/package/zerobias/s_apidev/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "7a43674a8f8727c20885d095a5a5085ca04ff57c2a17754fba83fa7a147b0b89",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_apidev/index.yml
+++ b/package/zerobias/s_apidev/index.yml
@@ -1,0 +1,12 @@
+id: 7e2815f9-34ea-4fcd-a10d-b48078faba71
+name: API and Integration Development
+description: API and systems integration development services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_apidev-segment.svg
+code: s_apidev
+externalId: API and Integration Development
+status: published
+parents:
+  - c_swdev
+tags: []
+aliases: []

--- a/package/zerobias/s_apidev/package.json
+++ b/package/zerobias/s_apidev/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_apidev",
+  "version": "1.0.0-rc.1",
+  "description": "API and systems integration development services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_apidev/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_apidev.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_swdev": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_apostille/.npmrc
+++ b/package/zerobias/s_apostille/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_apostille/build.gradle.kts
+++ b/package/zerobias/s_apostille/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_apostille/gate-stamp.json
+++ b/package/zerobias/s_apostille/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "f1ae25325d34307f609574d590751037c41a47629616dd6afcef841b5cd2a46a",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_apostille/index.yml
+++ b/package/zerobias/s_apostille/index.yml
@@ -1,0 +1,12 @@
+id: d567d204-aa71-4be5-863b-edfb49e05d53
+name: Apostille and Document Authentication
+description: Apostille and document authentication services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_apostille-segment.svg
+code: s_apostille
+externalId: Apostille and Document Authentication
+status: published
+parents:
+  - c_notary
+tags: []
+aliases: []

--- a/package/zerobias/s_apostille/package.json
+++ b/package/zerobias/s_apostille/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_apostille",
+  "version": "1.0.0-rc.1",
+  "description": "Apostille and document authentication services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_apostille/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_apostille.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_notary": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_appsectest/.npmrc
+++ b/package/zerobias/s_appsectest/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_appsectest/build.gradle.kts
+++ b/package/zerobias/s_appsectest/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_appsectest/gate-stamp.json
+++ b/package/zerobias/s_appsectest/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "6b5f07597a403cf8819e2274f42a73bd0e9ab5c35cc54909f368db8ec1f7d83c",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_appsectest/index.yml
+++ b/package/zerobias/s_appsectest/index.yml
@@ -1,0 +1,12 @@
+id: 07c742aa-1c66-4fef-9c15-7302b8dc2c9d
+name: Application Security Testing
+description: Application security testing services (SAST, DAST, IAST).
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_appsectest-segment.svg
+code: s_appsectest
+externalId: Application Security Testing
+status: published
+parents:
+  - c_appsec
+tags: []
+aliases: []

--- a/package/zerobias/s_appsectest/package.json
+++ b/package/zerobias/s_appsectest/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_appsectest",
+  "version": "1.0.0-rc.1",
+  "description": "Application security testing services (SAST, DAST, IAST).",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_appsectest/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_appsectest.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_appsec": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_audit/.npmrc
+++ b/package/zerobias/s_audit/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_audit/build.gradle.kts
+++ b/package/zerobias/s_audit/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_audit/gate-stamp.json
+++ b/package/zerobias/s_audit/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "d215df14364cc350338467ee88d63c87c0fefba697ededf9643b840d735ff318",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_audit/index.yml
+++ b/package/zerobias/s_audit/index.yml
@@ -1,0 +1,12 @@
+id: 0c42689d-2336-4509-8c9d-f2ae47d873c3
+name: Compliance Audit
+description: Compliance audit services (SOC 2, ISO 27001, HIPAA, PCI).
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_audit-segment.svg
+code: s_audit
+externalId: Compliance Audit
+status: published
+parents:
+  - c_audit
+tags: []
+aliases: []

--- a/package/zerobias/s_audit/package.json
+++ b/package/zerobias/s_audit/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_audit",
+  "version": "1.0.0-rc.1",
+  "description": "Compliance audit services (SOC 2, ISO 27001, HIPAA, PCI).",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_audit/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_audit.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_audit": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_awareness/.npmrc
+++ b/package/zerobias/s_awareness/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_awareness/build.gradle.kts
+++ b/package/zerobias/s_awareness/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_awareness/gate-stamp.json
+++ b/package/zerobias/s_awareness/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "6645e4300bf8c158d940508959b0851bd60867d3d3fcdfa7c8b653128bc2a12d",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_awareness/index.yml
+++ b/package/zerobias/s_awareness/index.yml
@@ -1,0 +1,12 @@
+id: b35b047b-38ff-4d39-8f49-e9db9db15b96
+name: Security Awareness Training
+description: Security awareness training services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_awareness-segment.svg
+code: s_awareness
+externalId: Security Awareness Training
+status: published
+parents:
+  - c_train
+tags: []
+aliases: []

--- a/package/zerobias/s_awareness/package.json
+++ b/package/zerobias/s_awareness/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_awareness",
+  "version": "1.0.0-rc.1",
+  "description": "Security awareness training services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_awareness/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_awareness.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_train": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_bcp/.npmrc
+++ b/package/zerobias/s_bcp/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_bcp/build.gradle.kts
+++ b/package/zerobias/s_bcp/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_bcp/gate-stamp.json
+++ b/package/zerobias/s_bcp/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "b885f287d81f1852a7eb7085bc398b8e0415434aa7450ff6a3923311e1dd2f5c",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_bcp/index.yml
+++ b/package/zerobias/s_bcp/index.yml
@@ -1,0 +1,12 @@
+id: 465aeedd-1141-40df-a912-0a796f0ceac0
+name: Business Continuity Planning
+description: Business continuity planning and advisory services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_bcp-segment.svg
+code: s_bcp
+externalId: Business Continuity Planning
+status: published
+parents:
+  - c_resilience
+tags: []
+aliases: []

--- a/package/zerobias/s_bcp/package.json
+++ b/package/zerobias/s_bcp/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_bcp",
+  "version": "1.0.0-rc.1",
+  "description": "Business continuity planning and advisory services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_bcp/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_bcp.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_resilience": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_bdr/.npmrc
+++ b/package/zerobias/s_bdr/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_bdr/build.gradle.kts
+++ b/package/zerobias/s_bdr/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_bdr/gate-stamp.json
+++ b/package/zerobias/s_bdr/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "6b35c228f1dc885ba9e799a7b305477f5b5264079ff33fe7305e72dc658d1e0a",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_bdr/index.yml
+++ b/package/zerobias/s_bdr/index.yml
@@ -1,0 +1,12 @@
+id: 465d8cbe-3bef-49c6-ad3c-a05563d17c67
+name: Backup and Disaster Recovery
+description: Backup and disaster recovery managed services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_bdr-segment.svg
+code: s_bdr
+externalId: Backup and Disaster Recovery
+status: published
+parents:
+  - c_resilience
+tags: []
+aliases: []

--- a/package/zerobias/s_bdr/package.json
+++ b/package/zerobias/s_bdr/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_bdr",
+  "version": "1.0.0-rc.1",
+  "description": "Backup and disaster recovery managed services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_bdr/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_bdr.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_resilience": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_bgcheck/.npmrc
+++ b/package/zerobias/s_bgcheck/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_bgcheck/build.gradle.kts
+++ b/package/zerobias/s_bgcheck/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_bgcheck/gate-stamp.json
+++ b/package/zerobias/s_bgcheck/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "e4077410599474a9194c5d483f0c700c6da5180e90bff8c660051114f8b6a950",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_bgcheck/index.yml
+++ b/package/zerobias/s_bgcheck/index.yml
@@ -1,0 +1,12 @@
+id: bae54f07-4dd1-4356-ba2b-ff5c9e10656c
+name: Background Checks
+description: Background check services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_bgcheck-segment.svg
+code: s_bgcheck
+externalId: Background Checks
+status: published
+parents:
+  - c_screening
+tags: []
+aliases: []

--- a/package/zerobias/s_bgcheck/package.json
+++ b/package/zerobias/s_bgcheck/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_bgcheck",
+  "version": "1.0.0-rc.1",
+  "description": "Background check services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_bgcheck/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_bgcheck.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_screening": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_bizlicense/.npmrc
+++ b/package/zerobias/s_bizlicense/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_bizlicense/build.gradle.kts
+++ b/package/zerobias/s_bizlicense/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_bizlicense/gate-stamp.json
+++ b/package/zerobias/s_bizlicense/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "9751b5c0e88ab86623239c31010c5b1c9f03c4b72af14186e90e58a998c9050a",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_bizlicense/index.yml
+++ b/package/zerobias/s_bizlicense/index.yml
@@ -1,0 +1,12 @@
+id: 82d3eb64-fd36-4e72-ad30-7958fd556d5e
+name: Business Licensing and Incorporation
+description: Business licensing and incorporation services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_bizlicense-segment.svg
+code: s_bizlicense
+externalId: Business Licensing and Incorporation
+status: published
+parents:
+  - c_bizcert
+tags: []
+aliases: []

--- a/package/zerobias/s_bizlicense/package.json
+++ b/package/zerobias/s_bizlicense/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_bizlicense",
+  "version": "1.0.0-rc.1",
+  "description": "Business licensing and incorporation services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_bizlicense/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_bizlicense.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_bizcert": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_bizprocess/.npmrc
+++ b/package/zerobias/s_bizprocess/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_bizprocess/build.gradle.kts
+++ b/package/zerobias/s_bizprocess/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_bizprocess/gate-stamp.json
+++ b/package/zerobias/s_bizprocess/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "98467c52f7c990610825ee7dc1b23caf5b116c7a6e9240db837eeb25c4dfa55b",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_bizprocess/index.yml
+++ b/package/zerobias/s_bizprocess/index.yml
@@ -1,0 +1,12 @@
+id: f1f87c7b-0840-411e-9946-ab88bebd5859
+name: Business Process Consulting
+description: Business process and operations consulting services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_bizprocess-segment.svg
+code: s_bizprocess
+externalId: Business Process Consulting
+status: published
+parents:
+  - c_advisory
+tags: []
+aliases: []

--- a/package/zerobias/s_bizprocess/package.json
+++ b/package/zerobias/s_bizprocess/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_bizprocess",
+  "version": "1.0.0-rc.1",
+  "description": "Business process and operations consulting services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_bizprocess/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_bizprocess.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_advisory": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_bonding/.npmrc
+++ b/package/zerobias/s_bonding/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_bonding/build.gradle.kts
+++ b/package/zerobias/s_bonding/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_bonding/gate-stamp.json
+++ b/package/zerobias/s_bonding/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "d8ed10d7e6e37ed0446a83a533c6674ca1b90e9e29ad217bbe1d4760229fa572",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_bonding/index.yml
+++ b/package/zerobias/s_bonding/index.yml
@@ -1,0 +1,12 @@
+id: a9ac3760-2f34-4f93-a31a-a1c66f2cdee5
+name: Surety and Bonding
+description: Surety and bonding services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_bonding-segment.svg
+code: s_bonding
+externalId: Surety and Bonding
+status: published
+parents:
+  - c_insurance
+tags: []
+aliases: []

--- a/package/zerobias/s_bonding/package.json
+++ b/package/zerobias/s_bonding/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_bonding",
+  "version": "1.0.0-rc.1",
+  "description": "Surety and bonding services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_bonding/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_bonding.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_insurance": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_bookkeeping/.npmrc
+++ b/package/zerobias/s_bookkeeping/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_bookkeeping/build.gradle.kts
+++ b/package/zerobias/s_bookkeeping/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_bookkeeping/gate-stamp.json
+++ b/package/zerobias/s_bookkeeping/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "255613273cdf97c8c0c0228c6f6142d7dcb8c0e5fb2710940f638db690179fe7",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_bookkeeping/index.yml
+++ b/package/zerobias/s_bookkeeping/index.yml
@@ -1,0 +1,12 @@
+id: d57429b3-f127-4350-ac60-8c1ce5343003
+name: Bookkeeping and Accounting
+description: Bookkeeping and accounting services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_bookkeeping-segment.svg
+code: s_bookkeeping
+externalId: Bookkeeping and Accounting
+status: published
+parents:
+  - c_tax
+tags: []
+aliases: []

--- a/package/zerobias/s_bookkeeping/package.json
+++ b/package/zerobias/s_bookkeeping/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_bookkeeping",
+  "version": "1.0.0-rc.1",
+  "description": "Bookkeeping and accounting services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_bookkeeping/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_bookkeeping.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_tax": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_breachrec/.npmrc
+++ b/package/zerobias/s_breachrec/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_breachrec/build.gradle.kts
+++ b/package/zerobias/s_breachrec/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_breachrec/gate-stamp.json
+++ b/package/zerobias/s_breachrec/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "63a3905480b543a2d77e7c7e1819a045415a39c312526262761de56a384a1adf",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_breachrec/index.yml
+++ b/package/zerobias/s_breachrec/index.yml
@@ -1,0 +1,12 @@
+id: e0d5d1ca-3904-4158-bd5d-007dd285c00c
+name: Breach and Ransomware Recovery
+description: Breach and ransomware recovery services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_breachrec-segment.svg
+code: s_breachrec
+externalId: Breach and Ransomware Recovery
+status: published
+parents:
+  - c_ir
+tags: []
+aliases: []

--- a/package/zerobias/s_breachrec/package.json
+++ b/package/zerobias/s_breachrec/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_breachrec",
+  "version": "1.0.0-rc.1",
+  "description": "Breach and ransomware recovery services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_breachrec/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_breachrec.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_ir": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_capture/.npmrc
+++ b/package/zerobias/s_capture/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_capture/build.gradle.kts
+++ b/package/zerobias/s_capture/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_capture/gate-stamp.json
+++ b/package/zerobias/s_capture/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "9cb5ea7772014b2d464eb8892b296ccd12a61a40b69ef900fc54855d79eeb55e",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_capture/index.yml
+++ b/package/zerobias/s_capture/index.yml
@@ -1,0 +1,12 @@
+id: af72b7ce-b47c-4b1a-911c-5b45968e7809
+name: Capture and Bid Management
+description: Capture and bid management services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_capture-segment.svg
+code: s_capture
+externalId: Capture and Bid Management
+status: published
+parents:
+  - c_procurement
+tags: []
+aliases: []

--- a/package/zerobias/s_capture/package.json
+++ b/package/zerobias/s_capture/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_capture",
+  "version": "1.0.0-rc.1",
+  "description": "Capture and bid management services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_capture/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_capture.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_procurement": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_ccaas/.npmrc
+++ b/package/zerobias/s_ccaas/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_ccaas/build.gradle.kts
+++ b/package/zerobias/s_ccaas/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_ccaas/gate-stamp.json
+++ b/package/zerobias/s_ccaas/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "ef3a294fc94a3b68bc076e480445fba1a4e154c4fb7ee6cd554a327d1a2f7e24",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_ccaas/index.yml
+++ b/package/zerobias/s_ccaas/index.yml
@@ -1,0 +1,12 @@
+id: 0f64688d-8b63-4621-9d01-6d14900997c2
+name: Contact Center Services (CCaaS)
+description: Contact center as a service.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_ccaas-segment.svg
+code: s_ccaas
+externalId: Contact Center Services (CCaaS)
+status: published
+parents:
+  - c_commsvc
+tags: []
+aliases: []

--- a/package/zerobias/s_ccaas/package.json
+++ b/package/zerobias/s_ccaas/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_ccaas",
+  "version": "1.0.0-rc.1",
+  "description": "Contact center as a service.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_ccaas/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_ccaas.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_commsvc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_certmgmt/.npmrc
+++ b/package/zerobias/s_certmgmt/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_certmgmt/build.gradle.kts
+++ b/package/zerobias/s_certmgmt/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_certmgmt/gate-stamp.json
+++ b/package/zerobias/s_certmgmt/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "35473c144203768f1592244400a05164424da84904d5deb6b31c2e41b2c892b9",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_certmgmt/index.yml
+++ b/package/zerobias/s_certmgmt/index.yml
@@ -1,0 +1,12 @@
+id: d94a6201-f5b5-420a-a736-5d1739515195
+name: Certificate Management
+description: Digital certificate management services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_certmgmt-segment.svg
+code: s_certmgmt
+externalId: Certificate Management
+status: published
+parents:
+  - c_crypto
+tags: []
+aliases: []

--- a/package/zerobias/s_certmgmt/package.json
+++ b/package/zerobias/s_certmgmt/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_certmgmt",
+  "version": "1.0.0-rc.1",
+  "description": "Digital certificate management services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_certmgmt/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_certmgmt.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_crypto": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_certprep/.npmrc
+++ b/package/zerobias/s_certprep/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_certprep/build.gradle.kts
+++ b/package/zerobias/s_certprep/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_certprep/gate-stamp.json
+++ b/package/zerobias/s_certprep/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "1282fe3c6fbdd61db5f7f9b5f9bc27b734664217eab81fe2537c0507f22d919c",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_certprep/index.yml
+++ b/package/zerobias/s_certprep/index.yml
@@ -1,0 +1,12 @@
+id: 8b8fd727-25c2-4410-853c-89a6a661c690
+name: Certification Preparation
+description: Certification preparation and support services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_certprep-segment.svg
+code: s_certprep
+externalId: Certification Preparation
+status: published
+parents:
+  - c_audit
+tags: []
+aliases: []

--- a/package/zerobias/s_certprep/package.json
+++ b/package/zerobias/s_certprep/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_certprep",
+  "version": "1.0.0-rc.1",
+  "description": "Certification preparation and support services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_certprep/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_certprep.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_audit": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_certtrain/.npmrc
+++ b/package/zerobias/s_certtrain/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_certtrain/build.gradle.kts
+++ b/package/zerobias/s_certtrain/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_certtrain/gate-stamp.json
+++ b/package/zerobias/s_certtrain/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "b0b436c1cc51d1e9b1d10f35cb31344c00dc4143238f475990c6cee73e636275",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_certtrain/index.yml
+++ b/package/zerobias/s_certtrain/index.yml
@@ -1,0 +1,12 @@
+id: d1a11fc8-1a2b-4808-aba5-3491ebfb466f
+name: Certification Training and Exam Prep
+description: Certification training and exam preparation services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_certtrain-segment.svg
+code: s_certtrain
+externalId: Certification Training and Exam Prep
+status: published
+parents:
+  - c_train
+tags: []
+aliases: []

--- a/package/zerobias/s_certtrain/package.json
+++ b/package/zerobias/s_certtrain/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_certtrain",
+  "version": "1.0.0-rc.1",
+  "description": "Certification training and exam preparation services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_certtrain/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_certtrain.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_train": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_cloudsec/.npmrc
+++ b/package/zerobias/s_cloudsec/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_cloudsec/build.gradle.kts
+++ b/package/zerobias/s_cloudsec/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_cloudsec/gate-stamp.json
+++ b/package/zerobias/s_cloudsec/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "d2185e14b29b7fab6c7a961e5e303e727778602190e651ecf8dab0f06b2fc34a",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_cloudsec/index.yml
+++ b/package/zerobias/s_cloudsec/index.yml
@@ -1,0 +1,12 @@
+id: 5a77a67e-ebe8-43dd-9af3-b1179d1f6fce
+name: Cloud Security Services
+description: Cloud security implementation and management services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_cloudsec-segment.svg
+code: s_cloudsec
+externalId: Cloud Security Services
+status: published
+parents:
+  - c_cloudsec
+tags: []
+aliases: []

--- a/package/zerobias/s_cloudsec/package.json
+++ b/package/zerobias/s_cloudsec/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_cloudsec",
+  "version": "1.0.0-rc.1",
+  "description": "Cloud security implementation and management services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_cloudsec/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_cloudsec.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_cloudsec": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_codereview/.npmrc
+++ b/package/zerobias/s_codereview/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_codereview/build.gradle.kts
+++ b/package/zerobias/s_codereview/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_codereview/gate-stamp.json
+++ b/package/zerobias/s_codereview/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "d29b00bd6fa2c20d4a0dbacb8089be407d3b5fa730001baf52fcb3c5b0dde816",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_codereview/index.yml
+++ b/package/zerobias/s_codereview/index.yml
@@ -1,0 +1,12 @@
+id: cc44fa5f-bacd-4dfb-8bc6-acf018383936
+name: Secure Code Review
+description: Secure code review services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_codereview-segment.svg
+code: s_codereview
+externalId: Secure Code Review
+status: published
+parents:
+  - c_appsec
+tags: []
+aliases: []

--- a/package/zerobias/s_codereview/package.json
+++ b/package/zerobias/s_codereview/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_codereview",
+  "version": "1.0.0-rc.1",
+  "description": "Secure code review services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_codereview/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_codereview.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_appsec": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_collab/.npmrc
+++ b/package/zerobias/s_collab/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_collab/build.gradle.kts
+++ b/package/zerobias/s_collab/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_collab/gate-stamp.json
+++ b/package/zerobias/s_collab/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "ab4f4a4a6c0bb146734aaac8e3f1c2d77a90875200a05a62b10483197f067cde",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_collab/index.yml
+++ b/package/zerobias/s_collab/index.yml
@@ -1,0 +1,12 @@
+id: a77543be-c020-4d0e-b68b-b8d7ab48a59d
+name: Collaboration Platform Management
+description: Collaboration platform management services (Slack, Teams, Zoom).
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_collab-segment.svg
+code: s_collab
+externalId: Collaboration Platform Management
+status: published
+parents:
+  - c_commsvc
+tags: []
+aliases: []

--- a/package/zerobias/s_collab/package.json
+++ b/package/zerobias/s_collab/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_collab",
+  "version": "1.0.0-rc.1",
+  "description": "Collaboration platform management services (Slack, Teams, Zoom).",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_collab/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_collab.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_commsvc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_comms/.npmrc
+++ b/package/zerobias/s_comms/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_comms/build.gradle.kts
+++ b/package/zerobias/s_comms/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_comms/gate-stamp.json
+++ b/package/zerobias/s_comms/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "9f35fc21968b5c99eeaa16866d8dcb5aad425a82d5ca8c71729b86f7cbab62a0",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_comms/index.yml
+++ b/package/zerobias/s_comms/index.yml
@@ -1,0 +1,12 @@
+id: 5fc98ead-f01d-4127-bd7b-3bb7e09096e2
+name: Telco and Communications
+description: Telecommunications and managed communications services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_comms-segment.svg
+code: s_comms
+externalId: Telco and Communications
+status: published
+parents:
+  - c_commsvc
+tags: []
+aliases: []

--- a/package/zerobias/s_comms/package.json
+++ b/package/zerobias/s_comms/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_comms",
+  "version": "1.0.0-rc.1",
+  "description": "Telecommunications and managed communications services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_comms/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_comms.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_commsvc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_commsarchive/.npmrc
+++ b/package/zerobias/s_commsarchive/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_commsarchive/build.gradle.kts
+++ b/package/zerobias/s_commsarchive/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_commsarchive/gate-stamp.json
+++ b/package/zerobias/s_commsarchive/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "52f6ab3bdffdcd2ad81506c201f16e7683cb9017775ddaa2cfdff115879711ce",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_commsarchive/index.yml
+++ b/package/zerobias/s_commsarchive/index.yml
@@ -1,0 +1,12 @@
+id: 8a4f7b7c-9877-48c2-8d09-e9d20256f92f
+name: Communications Archiving and Surveillance
+description: Regulated communications archiving and surveillance services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_commsarchive-segment.svg
+code: s_commsarchive
+externalId: Communications Archiving and Surveillance
+status: published
+parents:
+  - c_commsvc
+tags: []
+aliases: []

--- a/package/zerobias/s_commsarchive/package.json
+++ b/package/zerobias/s_commsarchive/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_commsarchive",
+  "version": "1.0.0-rc.1",
+  "description": "Regulated communications archiving and surveillance services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_commsarchive/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_commsarchive.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_commsvc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_compliance/.npmrc
+++ b/package/zerobias/s_compliance/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_compliance/build.gradle.kts
+++ b/package/zerobias/s_compliance/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_compliance/gate-stamp.json
+++ b/package/zerobias/s_compliance/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "8046809ee0f3c76f73cfbbc753a2c8bf9950ec9fb4113e80ca7252126afea221",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_compliance/index.yml
+++ b/package/zerobias/s_compliance/index.yml
@@ -1,0 +1,12 @@
+id: 222abdbd-0c07-4dee-afda-e4a2ff8feca1
+name: Compliance Monitoring
+description: Compliance monitoring and assessment services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_compliance-segment.svg
+code: s_compliance
+externalId: Compliance Monitoring
+status: published
+parents:
+  - c_grc
+tags: []
+aliases: []

--- a/package/zerobias/s_compliance/package.json
+++ b/package/zerobias/s_compliance/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_compliance",
+  "version": "1.0.0-rc.1",
+  "description": "Compliance monitoring and assessment services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_compliance/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_compliance.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_grc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_contractlaw/.npmrc
+++ b/package/zerobias/s_contractlaw/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_contractlaw/build.gradle.kts
+++ b/package/zerobias/s_contractlaw/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_contractlaw/gate-stamp.json
+++ b/package/zerobias/s_contractlaw/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "712d2c1f5ca98af0b2b9bf807a0780d76831528e74b523256949b2c17dd488e7",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_contractlaw/index.yml
+++ b/package/zerobias/s_contractlaw/index.yml
@@ -1,0 +1,12 @@
+id: 527519b4-2eaf-4d16-b7dd-3f5f46978556
+name: Contract and Commercial Law
+description: Contract and commercial legal services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_contractlaw-segment.svg
+code: s_contractlaw
+externalId: Contract and Commercial Law
+status: published
+parents:
+  - c_legal
+tags: []
+aliases: []

--- a/package/zerobias/s_contractlaw/package.json
+++ b/package/zerobias/s_contractlaw/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_contractlaw",
+  "version": "1.0.0-rc.1",
+  "description": "Contract and commercial legal services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_contractlaw/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_contractlaw.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_legal": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_cspm/.npmrc
+++ b/package/zerobias/s_cspm/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_cspm/build.gradle.kts
+++ b/package/zerobias/s_cspm/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_cspm/gate-stamp.json
+++ b/package/zerobias/s_cspm/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "30f5cd65cbc55b64bac46fda5d4f26dd829ac4070a006c1ded6fc75c29bbecf6",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_cspm/index.yml
+++ b/package/zerobias/s_cspm/index.yml
@@ -1,0 +1,12 @@
+id: 7fa06560-dc24-41f3-85bf-27dd636f56e5
+name: Cloud Posture Management (CSPM)
+description: Managed cloud security posture management services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_cspm-segment.svg
+code: s_cspm
+externalId: Cloud Posture Management (CSPM)
+status: published
+parents:
+  - c_cloudsec
+tags: []
+aliases: []

--- a/package/zerobias/s_cspm/package.json
+++ b/package/zerobias/s_cspm/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_cspm",
+  "version": "1.0.0-rc.1",
+  "description": "Managed cloud security posture management services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_cspm/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_cspm.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_cloudsec": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_cyberins/.npmrc
+++ b/package/zerobias/s_cyberins/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_cyberins/build.gradle.kts
+++ b/package/zerobias/s_cyberins/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_cyberins/gate-stamp.json
+++ b/package/zerobias/s_cyberins/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "4a19d2f720d5fc1533f6ad2e8a83f556b8da4a94f6f839bd788e4b7752adbd39",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_cyberins/index.yml
+++ b/package/zerobias/s_cyberins/index.yml
@@ -1,0 +1,12 @@
+id: 47e0f154-3ed3-48d4-9abc-ba381a23c52c
+name: Cyber Insurance Advisory
+description: Cyber insurance advisory and placement services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_cyberins-segment.svg
+code: s_cyberins
+externalId: Cyber Insurance Advisory
+status: published
+parents:
+  - c_insurance
+tags: []
+aliases: []

--- a/package/zerobias/s_cyberins/package.json
+++ b/package/zerobias/s_cyberins/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_cyberins",
+  "version": "1.0.0-rc.1",
+  "description": "Cyber insurance advisory and placement services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_cyberins/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_cyberins.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_insurance": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_cyberrange/.npmrc
+++ b/package/zerobias/s_cyberrange/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_cyberrange/build.gradle.kts
+++ b/package/zerobias/s_cyberrange/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_cyberrange/gate-stamp.json
+++ b/package/zerobias/s_cyberrange/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "a0aad1ff9681d0313479cd9eb8ec517370a1faf03039bc6b3840a2712a26508f",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_cyberrange/index.yml
+++ b/package/zerobias/s_cyberrange/index.yml
@@ -1,0 +1,12 @@
+id: 114c5ed4-0183-4221-9a81-3b85f8cbfcc2
+name: Cyber Range and Hands-on Lab Training
+description: Cyber range and hands-on lab training services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_cyberrange-segment.svg
+code: s_cyberrange
+externalId: Cyber Range and Hands-on Lab Training
+status: published
+parents:
+  - c_train
+tags: []
+aliases: []

--- a/package/zerobias/s_cyberrange/package.json
+++ b/package/zerobias/s_cyberrange/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_cyberrange",
+  "version": "1.0.0-rc.1",
+  "description": "Cyber range and hands-on lab training services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_cyberrange/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_cyberrange.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_train": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_dataclass/.npmrc
+++ b/package/zerobias/s_dataclass/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_dataclass/build.gradle.kts
+++ b/package/zerobias/s_dataclass/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_dataclass/gate-stamp.json
+++ b/package/zerobias/s_dataclass/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "2ac211618a2c92f19c77a7c00b9403a0fa0b573dac2e25ebc4c19c24ef8db741",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_dataclass/index.yml
+++ b/package/zerobias/s_dataclass/index.yml
@@ -1,0 +1,12 @@
+id: 88f8da99-0aae-4f6f-b0d8-c88792c33e30
+name: Data Classification and Handling
+description: Data classification and handling services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_dataclass-segment.svg
+code: s_dataclass
+externalId: Data Classification and Handling
+status: published
+parents:
+  - c_dataprivacy
+tags: []
+aliases: []

--- a/package/zerobias/s_dataclass/package.json
+++ b/package/zerobias/s_dataclass/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_dataclass",
+  "version": "1.0.0-rc.1",
+  "description": "Data classification and handling services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_dataclass/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_dataclass.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_dataprivacy": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_dataeng/.npmrc
+++ b/package/zerobias/s_dataeng/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_dataeng/build.gradle.kts
+++ b/package/zerobias/s_dataeng/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_dataeng/gate-stamp.json
+++ b/package/zerobias/s_dataeng/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "27835074c00fe72c4ebf82d5213118e5fa2091e9ab47340bf2ca390553d34572",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_dataeng/index.yml
+++ b/package/zerobias/s_dataeng/index.yml
@@ -1,0 +1,12 @@
+id: 1e8f65f2-5f08-4e32-96c2-156cdedb0bb4
+name: Data Engineering and Analytics
+description: Data engineering and analytics services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_dataeng-segment.svg
+code: s_dataeng
+externalId: Data Engineering and Analytics
+status: published
+parents:
+  - c_swdev
+tags: []
+aliases: []

--- a/package/zerobias/s_dataeng/package.json
+++ b/package/zerobias/s_dataeng/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_dataeng",
+  "version": "1.0.0-rc.1",
+  "description": "Data engineering and analytics services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_dataeng/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_dataeng.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_swdev": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_devsecops/.npmrc
+++ b/package/zerobias/s_devsecops/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_devsecops/build.gradle.kts
+++ b/package/zerobias/s_devsecops/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_devsecops/gate-stamp.json
+++ b/package/zerobias/s_devsecops/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "554eea3b940ebbf101a6d4eed49fb918cb0c4adfa9d4265a11f92a4d5dbf374c",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_devsecops/index.yml
+++ b/package/zerobias/s_devsecops/index.yml
@@ -1,0 +1,12 @@
+id: 10ef04ef-807a-42af-b9e5-d619c7dc52b5
+name: DevSecOps Consulting
+description: DevSecOps and secure SDLC consulting services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_devsecops-segment.svg
+code: s_devsecops
+externalId: DevSecOps Consulting
+status: published
+parents:
+  - c_appsec
+tags: []
+aliases: []

--- a/package/zerobias/s_devsecops/package.json
+++ b/package/zerobias/s_devsecops/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_devsecops",
+  "version": "1.0.0-rc.1",
+  "description": "DevSecOps and secure SDLC consulting services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_devsecops/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_devsecops.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_appsec": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_dlp/.npmrc
+++ b/package/zerobias/s_dlp/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_dlp/build.gradle.kts
+++ b/package/zerobias/s_dlp/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_dlp/gate-stamp.json
+++ b/package/zerobias/s_dlp/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "8bd61ccdf418def5eb121b10465cc1d4c8977d45722657ed966b81a0b11483e1",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_dlp/index.yml
+++ b/package/zerobias/s_dlp/index.yml
@@ -1,0 +1,12 @@
+id: 1e6b672d-7d35-4233-bcfe-4c34b8261c17
+name: Data Loss Prevention
+description: Managed data loss prevention services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_dlp-segment.svg
+code: s_dlp
+externalId: Data Loss Prevention
+status: published
+parents:
+  - c_dataprivacy
+tags: []
+aliases: []

--- a/package/zerobias/s_dlp/package.json
+++ b/package/zerobias/s_dlp/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_dlp",
+  "version": "1.0.0-rc.1",
+  "description": "Managed data loss prevention services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_dlp/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_dlp.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_dataprivacy": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_draas/.npmrc
+++ b/package/zerobias/s_draas/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_draas/build.gradle.kts
+++ b/package/zerobias/s_draas/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_draas/gate-stamp.json
+++ b/package/zerobias/s_draas/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "f46d3a25bc61926d15fc55938fb340249cd5dfbe73186895f35d332983e07fb8",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_draas/index.yml
+++ b/package/zerobias/s_draas/index.yml
@@ -1,0 +1,12 @@
+id: 84e76d15-05d4-4225-a6d3-0ee4a911dbbb
+name: Disaster Recovery as a Service (DRaaS)
+description: Disaster recovery as a service.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_draas-segment.svg
+code: s_draas
+externalId: Disaster Recovery as a Service (DRaaS)
+status: published
+parents:
+  - c_resilience
+tags: []
+aliases: []

--- a/package/zerobias/s_draas/package.json
+++ b/package/zerobias/s_draas/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_draas",
+  "version": "1.0.0-rc.1",
+  "description": "Disaster recovery as a service.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_draas/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_draas.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_resilience": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_duediligence/.npmrc
+++ b/package/zerobias/s_duediligence/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_duediligence/build.gradle.kts
+++ b/package/zerobias/s_duediligence/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_duediligence/gate-stamp.json
+++ b/package/zerobias/s_duediligence/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "a28feab336b202947ae1f5cdf4aac8c4876db3baa46586b52042b7c2489ad59d",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_duediligence/index.yml
+++ b/package/zerobias/s_duediligence/index.yml
@@ -1,0 +1,12 @@
+id: 8947bfbe-a981-4241-ac50-9eab14ad9b6b
+name: Due Diligence Investigations
+description: Due diligence investigation services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_duediligence-segment.svg
+code: s_duediligence
+externalId: Due Diligence Investigations
+status: published
+parents:
+  - c_screening
+tags: []
+aliases: []

--- a/package/zerobias/s_duediligence/package.json
+++ b/package/zerobias/s_duediligence/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_duediligence",
+  "version": "1.0.0-rc.1",
+  "description": "Due diligence investigation services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_duediligence/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_duediligence.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_screening": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_edrmgmt/.npmrc
+++ b/package/zerobias/s_edrmgmt/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_edrmgmt/build.gradle.kts
+++ b/package/zerobias/s_edrmgmt/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_edrmgmt/gate-stamp.json
+++ b/package/zerobias/s_edrmgmt/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "70c90c4b0f1f51e1cad9f2e72ff848563728b17fb70557fe716bfdda612c71ed",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_edrmgmt/index.yml
+++ b/package/zerobias/s_edrmgmt/index.yml
@@ -1,0 +1,12 @@
+id: 3bf493f3-1783-46ea-be17-dc14155a92bb
+name: Managed Endpoint Detection and Response
+description: Managed endpoint detection and response services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_edrmgmt-segment.svg
+code: s_edrmgmt
+externalId: Managed Endpoint Detection and Response
+status: published
+parents:
+  - c_endpoint
+tags: []
+aliases: []

--- a/package/zerobias/s_edrmgmt/package.json
+++ b/package/zerobias/s_edrmgmt/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_edrmgmt",
+  "version": "1.0.0-rc.1",
+  "description": "Managed endpoint detection and response services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_edrmgmt/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_edrmgmt.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_endpoint": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_empeligibility/.npmrc
+++ b/package/zerobias/s_empeligibility/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_empeligibility/build.gradle.kts
+++ b/package/zerobias/s_empeligibility/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_empeligibility/gate-stamp.json
+++ b/package/zerobias/s_empeligibility/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "341e4e437e4c6d2f9daac9dba23ccf3a76ebd6ffb4a10ef9b270498707157dfc",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_empeligibility/index.yml
+++ b/package/zerobias/s_empeligibility/index.yml
@@ -1,0 +1,12 @@
+id: 0cc27217-4099-4f18-9962-427b0846d439
+name: Employment Eligibility
+description: Employment eligibility verification services (I-9, E-Verify).
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_empeligibility-segment.svg
+code: s_empeligibility
+externalId: Employment Eligibility
+status: published
+parents:
+  - c_labor
+tags: []
+aliases: []

--- a/package/zerobias/s_empeligibility/package.json
+++ b/package/zerobias/s_empeligibility/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_empeligibility",
+  "version": "1.0.0-rc.1",
+  "description": "Employment eligibility verification services (I-9, E-Verify).",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_empeligibility/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_empeligibility.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_labor": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_encryption/.npmrc
+++ b/package/zerobias/s_encryption/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_encryption/build.gradle.kts
+++ b/package/zerobias/s_encryption/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_encryption/gate-stamp.json
+++ b/package/zerobias/s_encryption/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "4684128d395f619efac88c61ccefdc7d44d7dd2ebdb43b5904e41fe74d3a4d26",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_encryption/index.yml
+++ b/package/zerobias/s_encryption/index.yml
@@ -1,0 +1,12 @@
+id: b48d8bc6-3cc9-4fa9-a82a-d412247ed5c7
+name: Encryption Services
+description: Data encryption implementation and management services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_encryption-segment.svg
+code: s_encryption
+externalId: Encryption Services
+status: published
+parents:
+  - c_crypto
+tags: []
+aliases: []

--- a/package/zerobias/s_encryption/package.json
+++ b/package/zerobias/s_encryption/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_encryption",
+  "version": "1.0.0-rc.1",
+  "description": "Data encryption implementation and management services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_encryption/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_encryption.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_crypto": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_envcompliance/.npmrc
+++ b/package/zerobias/s_envcompliance/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_envcompliance/build.gradle.kts
+++ b/package/zerobias/s_envcompliance/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_envcompliance/gate-stamp.json
+++ b/package/zerobias/s_envcompliance/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "c74ac24c232e878cef8d9cd2222ecc9dd1ee364b969db7d16d3debac56b6f8e3",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_envcompliance/index.yml
+++ b/package/zerobias/s_envcompliance/index.yml
@@ -1,0 +1,12 @@
+id: 717e7e46-de25-48b0-a72b-1a3f7aa25fb9
+name: Environmental Compliance
+description: Environmental compliance services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_envcompliance-segment.svg
+code: s_envcompliance
+externalId: Environmental Compliance
+status: published
+parents:
+  - c_ehs
+tags: []
+aliases: []

--- a/package/zerobias/s_envcompliance/package.json
+++ b/package/zerobias/s_envcompliance/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_envcompliance",
+  "version": "1.0.0-rc.1",
+  "description": "Environmental compliance services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_envcompliance/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_envcompliance.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_ehs": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_envmon/.npmrc
+++ b/package/zerobias/s_envmon/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_envmon/build.gradle.kts
+++ b/package/zerobias/s_envmon/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_envmon/gate-stamp.json
+++ b/package/zerobias/s_envmon/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "6105278feb26282c2b363a31ac51edfac9d1098b6759059e5213fa6651e65bad",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_envmon/index.yml
+++ b/package/zerobias/s_envmon/index.yml
@@ -1,0 +1,12 @@
+id: 0b0bfcbc-6cd3-4855-84b9-3bc91d9e8c5b
+name: Environmental Monitoring
+description: Environmental controls monitoring services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_envmon-segment.svg
+code: s_envmon
+externalId: Environmental Monitoring
+status: published
+parents:
+  - c_physical
+tags: []
+aliases: []

--- a/package/zerobias/s_envmon/package.json
+++ b/package/zerobias/s_envmon/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_envmon",
+  "version": "1.0.0-rc.1",
+  "description": "Environmental controls monitoring services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_envmon/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_envmon.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_physical": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_esg/.npmrc
+++ b/package/zerobias/s_esg/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_esg/build.gradle.kts
+++ b/package/zerobias/s_esg/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_esg/gate-stamp.json
+++ b/package/zerobias/s_esg/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "b5bc219289b402264f6163eb292d1af73305828319fa2c6b9eecc0a86d024008",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_esg/index.yml
+++ b/package/zerobias/s_esg/index.yml
@@ -1,0 +1,12 @@
+id: f4b272fa-1b79-43b5-a5ca-559a116b9428
+name: ESG and Sustainability Reporting
+description: ESG and sustainability reporting services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_esg-segment.svg
+code: s_esg
+externalId: ESG and Sustainability Reporting
+status: published
+parents:
+  - c_ehs
+tags: []
+aliases: []

--- a/package/zerobias/s_esg/package.json
+++ b/package/zerobias/s_esg/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_esg",
+  "version": "1.0.0-rc.1",
+  "description": "ESG and sustainability reporting services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_esg/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_esg.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_ehs": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_exportcompliance/.npmrc
+++ b/package/zerobias/s_exportcompliance/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_exportcompliance/build.gradle.kts
+++ b/package/zerobias/s_exportcompliance/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_exportcompliance/gate-stamp.json
+++ b/package/zerobias/s_exportcompliance/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "13076a5bf281971b9f16b06da95e77d18daeed594742e08d205147c06ad64f34",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_exportcompliance/index.yml
+++ b/package/zerobias/s_exportcompliance/index.yml
@@ -1,0 +1,12 @@
+id: 0b2f1663-8848-49cb-b5c1-d42247ea8322
+name: Export Compliance
+description: Export compliance services (ITAR, EAR).
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_exportcompliance-segment.svg
+code: s_exportcompliance
+externalId: Export Compliance
+status: published
+parents:
+  - c_regapproval
+tags: []
+aliases: []

--- a/package/zerobias/s_exportcompliance/package.json
+++ b/package/zerobias/s_exportcompliance/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_exportcompliance",
+  "version": "1.0.0-rc.1",
+  "description": "Export compliance services (ITAR, EAR).",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_exportcompliance/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_exportcompliance.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_regapproval": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_facilityaccess/.npmrc
+++ b/package/zerobias/s_facilityaccess/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_facilityaccess/build.gradle.kts
+++ b/package/zerobias/s_facilityaccess/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_facilityaccess/gate-stamp.json
+++ b/package/zerobias/s_facilityaccess/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "167da6f8dae806547b5da880743c3f24c82b0a95531c4087660f0a6232828bb7",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_facilityaccess/index.yml
+++ b/package/zerobias/s_facilityaccess/index.yml
@@ -1,0 +1,12 @@
+id: d3b0da7d-a5e2-4ab9-86eb-c487a2a82d9e
+name: Facility Access Control
+description: Facility access control services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_facilityaccess-segment.svg
+code: s_facilityaccess
+externalId: Facility Access Control
+status: published
+parents:
+  - c_physical
+tags: []
+aliases: []

--- a/package/zerobias/s_facilityaccess/package.json
+++ b/package/zerobias/s_facilityaccess/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_facilityaccess",
+  "version": "1.0.0-rc.1",
+  "description": "Facility access control services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_facilityaccess/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_facilityaccess.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_physical": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_finadvisory/.npmrc
+++ b/package/zerobias/s_finadvisory/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_finadvisory/build.gradle.kts
+++ b/package/zerobias/s_finadvisory/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_finadvisory/gate-stamp.json
+++ b/package/zerobias/s_finadvisory/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "dc20b3dfdc8287988b9fde7605aa7603c26b7e746d9fbfd921aa3cfe20b42140",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_finadvisory/index.yml
+++ b/package/zerobias/s_finadvisory/index.yml
@@ -1,0 +1,12 @@
+id: 4ffc6262-9126-461e-aad3-137725bf3a60
+name: Financial and Accounting Advisory
+description: Financial and accounting advisory services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_finadvisory-segment.svg
+code: s_finadvisory
+externalId: Financial and Accounting Advisory
+status: published
+parents:
+  - c_advisory
+tags: []
+aliases: []

--- a/package/zerobias/s_finadvisory/package.json
+++ b/package/zerobias/s_finadvisory/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_finadvisory",
+  "version": "1.0.0-rc.1",
+  "description": "Financial and accounting advisory services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_finadvisory/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_finadvisory.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_advisory": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_finaudit/.npmrc
+++ b/package/zerobias/s_finaudit/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_finaudit/build.gradle.kts
+++ b/package/zerobias/s_finaudit/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_finaudit/gate-stamp.json
+++ b/package/zerobias/s_finaudit/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "a21b6756706be56d84d618bd7ac7e9087e49c86b2f70542c998663479c0c079c",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_finaudit/index.yml
+++ b/package/zerobias/s_finaudit/index.yml
@@ -1,0 +1,12 @@
+id: f0d2747a-5e96-4383-aabe-2be33978b9c1
+name: Financial Statement Audit
+description: Financial statement audit and assurance services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_finaudit-segment.svg
+code: s_finaudit
+externalId: Financial Statement Audit
+status: published
+parents:
+  - c_tax
+tags: []
+aliases: []

--- a/package/zerobias/s_finaudit/package.json
+++ b/package/zerobias/s_finaudit/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_finaudit",
+  "version": "1.0.0-rc.1",
+  "description": "Financial statement audit and assurance services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_finaudit/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_finaudit.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_tax": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_forensics/.npmrc
+++ b/package/zerobias/s_forensics/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_forensics/build.gradle.kts
+++ b/package/zerobias/s_forensics/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_forensics/gate-stamp.json
+++ b/package/zerobias/s_forensics/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "9f40497e0f5e198e597fde04721041306a30a668abcb3a8186cdc266d7a700c8",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_forensics/index.yml
+++ b/package/zerobias/s_forensics/index.yml
@@ -1,0 +1,12 @@
+id: 492854e1-b26c-4d91-82e0-8129ee2b0f45
+name: Digital Forensics
+description: Digital forensics and investigation services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_forensics-segment.svg
+code: s_forensics
+externalId: Digital Forensics
+status: published
+parents:
+  - c_ir
+tags: []
+aliases: []

--- a/package/zerobias/s_forensics/package.json
+++ b/package/zerobias/s_forensics/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_forensics",
+  "version": "1.0.0-rc.1",
+  "description": "Digital forensics and investigation services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_forensics/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_forensics.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_ir": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_fwmgmt/.npmrc
+++ b/package/zerobias/s_fwmgmt/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_fwmgmt/build.gradle.kts
+++ b/package/zerobias/s_fwmgmt/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_fwmgmt/gate-stamp.json
+++ b/package/zerobias/s_fwmgmt/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "be124645c8e1381f402137a38b686afb48decdcc530206bb6ff0e121b7884249",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_fwmgmt/index.yml
+++ b/package/zerobias/s_fwmgmt/index.yml
@@ -1,0 +1,12 @@
+id: 7d6f74a2-89fb-400c-9c3f-e973c35831f2
+name: Firewall Management
+description: Managed firewall services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_fwmgmt-segment.svg
+code: s_fwmgmt
+externalId: Firewall Management
+status: published
+parents:
+  - c_netsec
+tags: []
+aliases: []

--- a/package/zerobias/s_fwmgmt/package.json
+++ b/package/zerobias/s_fwmgmt/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_fwmgmt",
+  "version": "1.0.0-rc.1",
+  "description": "Managed firewall services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_fwmgmt/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_fwmgmt.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_netsec": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_gapassess/.npmrc
+++ b/package/zerobias/s_gapassess/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_gapassess/build.gradle.kts
+++ b/package/zerobias/s_gapassess/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_gapassess/gate-stamp.json
+++ b/package/zerobias/s_gapassess/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "ce147d85174371db90a8db69458186d837139e2bc041f71df85d507d8d18ee29",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_gapassess/index.yml
+++ b/package/zerobias/s_gapassess/index.yml
@@ -1,0 +1,12 @@
+id: 109def4e-bc6f-44dc-b274-7ecc12e2b5d7
+name: Gap Assessment
+description: Compliance and security gap assessment services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_gapassess-segment.svg
+code: s_gapassess
+externalId: Gap Assessment
+status: published
+parents:
+  - c_audit
+tags: []
+aliases: []

--- a/package/zerobias/s_gapassess/package.json
+++ b/package/zerobias/s_gapassess/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_gapassess",
+  "version": "1.0.0-rc.1",
+  "description": "Compliance and security gap assessment services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_gapassess/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_gapassess.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_audit": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_grantwriting/.npmrc
+++ b/package/zerobias/s_grantwriting/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_grantwriting/build.gradle.kts
+++ b/package/zerobias/s_grantwriting/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_grantwriting/gate-stamp.json
+++ b/package/zerobias/s_grantwriting/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "991c4e67ad5022c2fff0f9fc234046b5d037bd88f6959b3921b4ac1005991c61",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_grantwriting/index.yml
+++ b/package/zerobias/s_grantwriting/index.yml
@@ -1,0 +1,12 @@
+id: 88ac7b0f-50ab-4d46-82f5-8c4709f2a4f6
+name: Grant Writing
+description: Grant writing services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_grantwriting-segment.svg
+code: s_grantwriting
+externalId: Grant Writing
+status: published
+parents:
+  - c_procurement
+tags: []
+aliases: []

--- a/package/zerobias/s_grantwriting/package.json
+++ b/package/zerobias/s_grantwriting/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_grantwriting",
+  "version": "1.0.0-rc.1",
+  "description": "Grant writing services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_grantwriting/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_grantwriting.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_procurement": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_gsasam/.npmrc
+++ b/package/zerobias/s_gsasam/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_gsasam/build.gradle.kts
+++ b/package/zerobias/s_gsasam/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_gsasam/gate-stamp.json
+++ b/package/zerobias/s_gsasam/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "2be8f02956a58cf8376f8ceebfb3497963333e3f197e816ce46014b4527e931a",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_gsasam/index.yml
+++ b/package/zerobias/s_gsasam/index.yml
@@ -1,0 +1,12 @@
+id: b80c4dd5-58cb-493a-befd-dbb359b9f3a3
+name: GSA Schedule and SAM Registration
+description: GSA Schedule and SAM registration services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_gsasam-segment.svg
+code: s_gsasam
+externalId: GSA Schedule and SAM Registration
+status: published
+parents:
+  - c_bizcert
+tags: []
+aliases: []

--- a/package/zerobias/s_gsasam/package.json
+++ b/package/zerobias/s_gsasam/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_gsasam",
+  "version": "1.0.0-rc.1",
+  "description": "GSA Schedule and SAM registration services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_gsasam/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_gsasam.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_bizcert": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_hardening/.npmrc
+++ b/package/zerobias/s_hardening/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_hardening/build.gradle.kts
+++ b/package/zerobias/s_hardening/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_hardening/gate-stamp.json
+++ b/package/zerobias/s_hardening/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "6f12d99b807c01981f2eae109a1b80c6714a2d9da37c0f2169a60c482509dcc1",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_hardening/index.yml
+++ b/package/zerobias/s_hardening/index.yml
@@ -1,0 +1,12 @@
+id: 121879fa-a3ec-46e0-bf42-284cc422651a
+name: Secure Configuration and Hardening
+description: Secure configuration and system hardening services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_hardening-segment.svg
+code: s_hardening
+externalId: Secure Configuration and Hardening
+status: published
+parents:
+  - c_itops
+tags: []
+aliases: []

--- a/package/zerobias/s_hardening/package.json
+++ b/package/zerobias/s_hardening/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_hardening",
+  "version": "1.0.0-rc.1",
+  "description": "Secure configuration and system hardening services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_hardening/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_hardening.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_itops": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_helpdesk/.npmrc
+++ b/package/zerobias/s_helpdesk/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_helpdesk/build.gradle.kts
+++ b/package/zerobias/s_helpdesk/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_helpdesk/gate-stamp.json
+++ b/package/zerobias/s_helpdesk/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "966f1c9004a99bcd3f0013d21be73f363a451a7e9e73698406472fb9abbbdd8b",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_helpdesk/index.yml
+++ b/package/zerobias/s_helpdesk/index.yml
@@ -1,0 +1,12 @@
+id: 7cfdc792-a871-4fa8-a0ae-a31ee0882be4
+name: Help Desk and End-User Support
+description: Help desk and end-user support services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_helpdesk-segment.svg
+code: s_helpdesk
+externalId: Help Desk and End-User Support
+status: published
+parents:
+  - c_itops
+tags: []
+aliases: []

--- a/package/zerobias/s_helpdesk/package.json
+++ b/package/zerobias/s_helpdesk/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_helpdesk",
+  "version": "1.0.0-rc.1",
+  "description": "Help desk and end-user support services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_helpdesk/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_helpdesk.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_itops": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_hrconsulting/.npmrc
+++ b/package/zerobias/s_hrconsulting/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_hrconsulting/build.gradle.kts
+++ b/package/zerobias/s_hrconsulting/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_hrconsulting/gate-stamp.json
+++ b/package/zerobias/s_hrconsulting/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "66458b18dd418f7410c6fa96d6c0badc17fb60be3cf0e3a454c973ff2de6a6a3",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_hrconsulting/index.yml
+++ b/package/zerobias/s_hrconsulting/index.yml
@@ -1,0 +1,12 @@
+id: f3c71b47-6820-4428-828f-d1ccc68b20b4
+name: HR Consulting
+description: Human resources consulting services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_hrconsulting-segment.svg
+code: s_hrconsulting
+externalId: HR Consulting
+status: published
+parents:
+  - c_hr
+tags: []
+aliases: []

--- a/package/zerobias/s_hrconsulting/package.json
+++ b/package/zerobias/s_hrconsulting/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_hrconsulting",
+  "version": "1.0.0-rc.1",
+  "description": "Human resources consulting services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_hrconsulting/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_hrconsulting.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_hr": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_iam/.npmrc
+++ b/package/zerobias/s_iam/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_iam/build.gradle.kts
+++ b/package/zerobias/s_iam/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_iam/gate-stamp.json
+++ b/package/zerobias/s_iam/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "89fb39cb1b803a3deeb5b043adcb92d89525f95074120b5678ef7cd6872df8e0",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_iam/index.yml
+++ b/package/zerobias/s_iam/index.yml
@@ -1,0 +1,12 @@
+id: 8cec43d8-94ba-404e-825c-57af0297e906
+name: Managed IAM
+description: Managed identity and access management services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_iam-segment.svg
+code: s_iam
+externalId: Managed IAM
+status: published
+parents:
+  - c_idam
+tags: []
+aliases: []

--- a/package/zerobias/s_iam/package.json
+++ b/package/zerobias/s_iam/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_iam",
+  "version": "1.0.0-rc.1",
+  "description": "Managed identity and access management services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_iam/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_iam.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_idam": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_idverify/.npmrc
+++ b/package/zerobias/s_idverify/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_idverify/build.gradle.kts
+++ b/package/zerobias/s_idverify/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_idverify/gate-stamp.json
+++ b/package/zerobias/s_idverify/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "06112389acd46ce72ac7b25e6948dd1739101745ba3bb220725cb5e23d5147cf",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_idverify/index.yml
+++ b/package/zerobias/s_idverify/index.yml
@@ -1,0 +1,12 @@
+id: 741e09e8-2bc5-4afa-a214-62ddcca341cb
+name: Identity Verification
+description: Identity verification services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_idverify-segment.svg
+code: s_idverify
+externalId: Identity Verification
+status: published
+parents:
+  - c_screening
+tags: []
+aliases: []

--- a/package/zerobias/s_idverify/package.json
+++ b/package/zerobias/s_idverify/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_idverify",
+  "version": "1.0.0-rc.1",
+  "description": "Identity verification services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_idverify/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_idverify.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_screening": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_iga/.npmrc
+++ b/package/zerobias/s_iga/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_iga/build.gradle.kts
+++ b/package/zerobias/s_iga/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_iga/gate-stamp.json
+++ b/package/zerobias/s_iga/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "4aee3a25d5e78802d138ac62413f356a81fd956814cfe4e9af60747301f91a89",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_iga/index.yml
+++ b/package/zerobias/s_iga/index.yml
@@ -1,0 +1,12 @@
+id: 8a104362-8ae3-4692-b95d-688d2f7ebddc
+name: Identity Governance (IGA)
+description: Identity governance and administration services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_iga-segment.svg
+code: s_iga
+externalId: Identity Governance (IGA)
+status: published
+parents:
+  - c_idam
+tags: []
+aliases: []

--- a/package/zerobias/s_iga/package.json
+++ b/package/zerobias/s_iga/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_iga",
+  "version": "1.0.0-rc.1",
+  "description": "Identity governance and administration services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_iga/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_iga.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_idam": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_immigration/.npmrc
+++ b/package/zerobias/s_immigration/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_immigration/build.gradle.kts
+++ b/package/zerobias/s_immigration/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_immigration/gate-stamp.json
+++ b/package/zerobias/s_immigration/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "3001ea63805680f696e48070d6e1ac2243ba221300e394fc48a7df2d5c0b3cf6",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_immigration/index.yml
+++ b/package/zerobias/s_immigration/index.yml
@@ -1,0 +1,12 @@
+id: e2a939bd-f366-473b-a2a6-d1ca8bc4b7e6
+name: Immigration and Visa
+description: Immigration and visa services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_immigration-segment.svg
+code: s_immigration
+externalId: Immigration and Visa
+status: published
+parents:
+  - c_labor
+tags: []
+aliases: []

--- a/package/zerobias/s_immigration/package.json
+++ b/package/zerobias/s_immigration/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_immigration",
+  "version": "1.0.0-rc.1",
+  "description": "Immigration and visa services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_immigration/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_immigration.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_labor": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_inframgmt/.npmrc
+++ b/package/zerobias/s_inframgmt/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_inframgmt/build.gradle.kts
+++ b/package/zerobias/s_inframgmt/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_inframgmt/gate-stamp.json
+++ b/package/zerobias/s_inframgmt/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "f1a42a7f4cc03520eb6c5f12fd1eee58ca432813e54d793a9f4c165457d26257",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_inframgmt/index.yml
+++ b/package/zerobias/s_inframgmt/index.yml
@@ -1,0 +1,12 @@
+id: e70aeade-ce73-47fe-9769-194de76f191d
+name: Server and Infrastructure Management
+description: Server, network, and infrastructure management services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_inframgmt-segment.svg
+code: s_inframgmt
+externalId: Server and Infrastructure Management
+status: published
+parents:
+  - c_itops
+tags: []
+aliases: []

--- a/package/zerobias/s_inframgmt/package.json
+++ b/package/zerobias/s_inframgmt/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_inframgmt",
+  "version": "1.0.0-rc.1",
+  "description": "Server, network, and infrastructure management services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_inframgmt/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_inframgmt.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_itops": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_iotsec/.npmrc
+++ b/package/zerobias/s_iotsec/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_iotsec/build.gradle.kts
+++ b/package/zerobias/s_iotsec/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_iotsec/gate-stamp.json
+++ b/package/zerobias/s_iotsec/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "958f77e37c758619d678defb8e6bdce53fc61ca2110fea2ed349b43b915dd9ce",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_iotsec/index.yml
+++ b/package/zerobias/s_iotsec/index.yml
@@ -1,0 +1,12 @@
+id: 309a7f90-a0d1-4899-ae41-0e8d8755a665
+name: IoT Security
+description: Internet of Things security services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_iotsec-segment.svg
+code: s_iotsec
+externalId: IoT Security
+status: published
+parents:
+  - c_otsec
+tags: []
+aliases: []

--- a/package/zerobias/s_iotsec/package.json
+++ b/package/zerobias/s_iotsec/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_iotsec",
+  "version": "1.0.0-rc.1",
+  "description": "Internet of Things security services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_iotsec/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_iotsec.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_otsec": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_iplaw/.npmrc
+++ b/package/zerobias/s_iplaw/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_iplaw/build.gradle.kts
+++ b/package/zerobias/s_iplaw/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_iplaw/gate-stamp.json
+++ b/package/zerobias/s_iplaw/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "5e7c26a07b6e00a3c16d7668dc9dba7684c4133c066d643062d69bdab47a53a4",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_iplaw/index.yml
+++ b/package/zerobias/s_iplaw/index.yml
@@ -1,0 +1,12 @@
+id: 9958668d-b97f-4696-9ff3-a94d037385a6
+name: Intellectual Property and Licensing
+description: Intellectual property and licensing legal services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_iplaw-segment.svg
+code: s_iplaw
+externalId: Intellectual Property and Licensing
+status: published
+parents:
+  - c_legal
+tags: []
+aliases: []

--- a/package/zerobias/s_iplaw/package.json
+++ b/package/zerobias/s_iplaw/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_iplaw",
+  "version": "1.0.0-rc.1",
+  "description": "Intellectual property and licensing legal services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_iplaw/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_iplaw.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_legal": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_ir/.npmrc
+++ b/package/zerobias/s_ir/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_ir/build.gradle.kts
+++ b/package/zerobias/s_ir/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_ir/gate-stamp.json
+++ b/package/zerobias/s_ir/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "4e51d7e73533da16c03ee7e681b17687f914567e19d0f56aeb3a9f688e31b819",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_ir/index.yml
+++ b/package/zerobias/s_ir/index.yml
@@ -1,0 +1,12 @@
+id: 3fec3965-abd2-47f9-9dec-e95584ae4be6
+name: Incident Response
+description: Security incident response services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_ir-segment.svg
+code: s_ir
+externalId: Incident Response
+status: published
+parents:
+  - c_ir
+tags: []
+aliases: []

--- a/package/zerobias/s_ir/package.json
+++ b/package/zerobias/s_ir/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_ir",
+  "version": "1.0.0-rc.1",
+  "description": "Security incident response services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_ir/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_ir.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_ir": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_itam/.npmrc
+++ b/package/zerobias/s_itam/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_itam/build.gradle.kts
+++ b/package/zerobias/s_itam/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_itam/gate-stamp.json
+++ b/package/zerobias/s_itam/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "656eed6369be47503549310cd94ad5ebec1e49f20d331b40b6a328160d32ab60",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_itam/index.yml
+++ b/package/zerobias/s_itam/index.yml
@@ -1,0 +1,12 @@
+id: 7011b12c-4fb1-43e9-bd7f-fd34589ba1ce
+name: IT Asset Management
+description: IT asset management services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_itam-segment.svg
+code: s_itam
+externalId: IT Asset Management
+status: published
+parents:
+  - c_asset
+tags: []
+aliases: []

--- a/package/zerobias/s_itam/package.json
+++ b/package/zerobias/s_itam/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_itam",
+  "version": "1.0.0-rc.1",
+  "description": "IT asset management services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_itam/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_itam.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_asset": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_itsm/.npmrc
+++ b/package/zerobias/s_itsm/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_itsm/build.gradle.kts
+++ b/package/zerobias/s_itsm/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_itsm/gate-stamp.json
+++ b/package/zerobias/s_itsm/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "3a3f23a7298e5bb9010428f0d23b28d3e756f3b5655d84fa28e9c1b2470e276e",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_itsm/index.yml
+++ b/package/zerobias/s_itsm/index.yml
@@ -1,0 +1,12 @@
+id: bce43eb6-5ef5-4da2-9049-9fb7c528a1ee
+name: IT Service Management (ITSM)
+description: IT service management and ITIL process services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_itsm-segment.svg
+code: s_itsm
+externalId: IT Service Management (ITSM)
+status: published
+parents:
+  - c_itops
+tags: []
+aliases: []

--- a/package/zerobias/s_itsm/package.json
+++ b/package/zerobias/s_itsm/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_itsm",
+  "version": "1.0.0-rc.1",
+  "description": "IT service management and ITIL process services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_itsm/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_itsm.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_itops": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_ivv/.npmrc
+++ b/package/zerobias/s_ivv/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_ivv/build.gradle.kts
+++ b/package/zerobias/s_ivv/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_ivv/gate-stamp.json
+++ b/package/zerobias/s_ivv/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "6fcae640fd18d409b07cfd8d0a688e6b71871d7fc2b890dc50f2f00c322b5dc2",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_ivv/index.yml
+++ b/package/zerobias/s_ivv/index.yml
@@ -1,0 +1,12 @@
+id: 93231618-46f7-4b05-9983-f432336fa78c
+name: Independent Verification and Validation
+description: Independent verification and validation services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_ivv-segment.svg
+code: s_ivv
+externalId: Independent Verification and Validation
+status: published
+parents:
+  - c_validation
+tags: []
+aliases: []

--- a/package/zerobias/s_ivv/package.json
+++ b/package/zerobias/s_ivv/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_ivv",
+  "version": "1.0.0-rc.1",
+  "description": "Independent verification and validation services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_ivv/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_ivv.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_validation": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_kyc/.npmrc
+++ b/package/zerobias/s_kyc/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_kyc/build.gradle.kts
+++ b/package/zerobias/s_kyc/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_kyc/gate-stamp.json
+++ b/package/zerobias/s_kyc/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "a0952c1768eba3a7a05ae53fe42e248395135d1044cbbb9b77dbc4c2bd56d1d9",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_kyc/index.yml
+++ b/package/zerobias/s_kyc/index.yml
@@ -1,0 +1,12 @@
+id: 5726a700-2ce7-4349-a09f-387a59b5765f
+name: KYC and KYB
+description: Know-your-customer and know-your-business services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_kyc-segment.svg
+code: s_kyc
+externalId: KYC and KYB
+status: published
+parents:
+  - c_fincrime
+tags: []
+aliases: []

--- a/package/zerobias/s_kyc/package.json
+++ b/package/zerobias/s_kyc/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_kyc",
+  "version": "1.0.0-rc.1",
+  "description": "Know-your-customer and know-your-business services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_kyc/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_kyc.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_fincrime": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_laborlaw/.npmrc
+++ b/package/zerobias/s_laborlaw/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_laborlaw/build.gradle.kts
+++ b/package/zerobias/s_laborlaw/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_laborlaw/gate-stamp.json
+++ b/package/zerobias/s_laborlaw/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "1f4630c47b128be2e57d66362118832941c9212f49c282822edf882b0cd27863",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_laborlaw/index.yml
+++ b/package/zerobias/s_laborlaw/index.yml
@@ -1,0 +1,12 @@
+id: b6fd6c4c-f40f-4bd4-a3d3-efc44c347d0e
+name: Labor Law Compliance
+description: Labor law compliance services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_laborlaw-segment.svg
+code: s_laborlaw
+externalId: Labor Law Compliance
+status: published
+parents:
+  - c_labor
+tags: []
+aliases: []

--- a/package/zerobias/s_laborlaw/package.json
+++ b/package/zerobias/s_laborlaw/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_laborlaw",
+  "version": "1.0.0-rc.1",
+  "description": "Labor law compliance services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_laborlaw/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_laborlaw.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_labor": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_liabilityins/.npmrc
+++ b/package/zerobias/s_liabilityins/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_liabilityins/build.gradle.kts
+++ b/package/zerobias/s_liabilityins/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_liabilityins/gate-stamp.json
+++ b/package/zerobias/s_liabilityins/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "faa061942e07f2e67455f5ca3e0be52f451103793f37aaa4404afbed9d82658a",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_liabilityins/index.yml
+++ b/package/zerobias/s_liabilityins/index.yml
@@ -1,0 +1,12 @@
+id: ede17228-746f-4532-837c-134e0960149b
+name: Liability Insurance Advisory
+description: Liability and coverage insurance advisory services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_liabilityins-segment.svg
+code: s_liabilityins
+externalId: Liability Insurance Advisory
+status: published
+parents:
+  - c_insurance
+tags: []
+aliases: []

--- a/package/zerobias/s_liabilityins/package.json
+++ b/package/zerobias/s_liabilityins/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_liabilityins",
+  "version": "1.0.0-rc.1",
+  "description": "Liability and coverage insurance advisory services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_liabilityins/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_liabilityins.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_insurance": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_litsupport/.npmrc
+++ b/package/zerobias/s_litsupport/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_litsupport/build.gradle.kts
+++ b/package/zerobias/s_litsupport/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_litsupport/gate-stamp.json
+++ b/package/zerobias/s_litsupport/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "d7270340be7ab843d62385c172737eccea066f8f4496971e46b118da67a08aca",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_litsupport/index.yml
+++ b/package/zerobias/s_litsupport/index.yml
@@ -1,0 +1,12 @@
+id: bcc4a38b-67d6-4f63-a589-e5303a3ad2f3
+name: Litigation and eDiscovery Support
+description: Litigation support and eDiscovery services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_litsupport-segment.svg
+code: s_litsupport
+externalId: Litigation and eDiscovery Support
+status: published
+parents:
+  - c_legal
+tags: []
+aliases: []

--- a/package/zerobias/s_litsupport/package.json
+++ b/package/zerobias/s_litsupport/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_litsupport",
+  "version": "1.0.0-rc.1",
+  "description": "Litigation support and eDiscovery services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_litsupport/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_litsupport.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_legal": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_madd/.npmrc
+++ b/package/zerobias/s_madd/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_madd/build.gradle.kts
+++ b/package/zerobias/s_madd/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_madd/gate-stamp.json
+++ b/package/zerobias/s_madd/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "4222e7ec8171a9ef1026463dfc45f04c73a07cc52cc7b1da46742fc57ae6769e",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_madd/index.yml
+++ b/package/zerobias/s_madd/index.yml
@@ -1,0 +1,12 @@
+id: b7454b83-5d43-4af5-bf9c-e6a71531eaf9
+name: Mergers, Acquisitions and Due Diligence
+description: Mergers, acquisitions, and due diligence advisory services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_madd-segment.svg
+code: s_madd
+externalId: Mergers, Acquisitions and Due Diligence
+status: published
+parents:
+  - c_advisory
+tags: []
+aliases: []

--- a/package/zerobias/s_madd/package.json
+++ b/package/zerobias/s_madd/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_madd",
+  "version": "1.0.0-rc.1",
+  "description": "Mergers, acquisitions, and due diligence advisory services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_madd/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_madd.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_advisory": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_mdm/.npmrc
+++ b/package/zerobias/s_mdm/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_mdm/build.gradle.kts
+++ b/package/zerobias/s_mdm/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_mdm/gate-stamp.json
+++ b/package/zerobias/s_mdm/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "1006b4952d18906e69cbfbe6b99ccc1869ae415b649e7f8b31a853511b0a62ce",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_mdm/index.yml
+++ b/package/zerobias/s_mdm/index.yml
@@ -1,0 +1,12 @@
+id: b78e80aa-e04d-43a8-95dd-7e05cea205b8
+name: Mobile Device Management
+description: Mobile device management services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_mdm-segment.svg
+code: s_mdm
+externalId: Mobile Device Management
+status: published
+parents:
+  - c_endpoint
+tags: []
+aliases: []

--- a/package/zerobias/s_mdm/package.json
+++ b/package/zerobias/s_mdm/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_mdm",
+  "version": "1.0.0-rc.1",
+  "description": "Mobile device management services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_mdm/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_mdm.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_endpoint": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_mdr/.npmrc
+++ b/package/zerobias/s_mdr/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_mdr/build.gradle.kts
+++ b/package/zerobias/s_mdr/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_mdr/gate-stamp.json
+++ b/package/zerobias/s_mdr/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "389392024bd614807e0363f5375a33ec6acd23488c02fcf47961d84f921155e0",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_mdr/index.yml
+++ b/package/zerobias/s_mdr/index.yml
@@ -1,0 +1,12 @@
+id: 5f0bbca1-cdef-4a46-8a5d-924dcab03f2e
+name: Managed Detection and Response (MDR)
+description: Managed threat detection and response services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_mdr-segment.svg
+code: s_mdr
+externalId: Managed Detection and Response (MDR)
+status: published
+parents:
+  - c_secops
+tags: []
+aliases: []

--- a/package/zerobias/s_mdr/package.json
+++ b/package/zerobias/s_mdr/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_mdr",
+  "version": "1.0.0-rc.1",
+  "description": "Managed threat detection and response services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_mdr/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_mdr.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_secops": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_messaging/.npmrc
+++ b/package/zerobias/s_messaging/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_messaging/build.gradle.kts
+++ b/package/zerobias/s_messaging/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_messaging/gate-stamp.json
+++ b/package/zerobias/s_messaging/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "dbe8e12c2e16181867f96008ed74acb4ca07ac4ea0a87f7bdaaf23a631780d36",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_messaging/index.yml
+++ b/package/zerobias/s_messaging/index.yml
@@ -1,0 +1,12 @@
+id: 5e506820-acf8-4282-87dc-c637f98b3869
+name: Managed Email and Messaging
+description: Managed email and messaging services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_messaging-segment.svg
+code: s_messaging
+externalId: Managed Email and Messaging
+status: published
+parents:
+  - c_commsvc
+tags: []
+aliases: []

--- a/package/zerobias/s_messaging/package.json
+++ b/package/zerobias/s_messaging/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_messaging",
+  "version": "1.0.0-rc.1",
+  "description": "Managed email and messaging services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_messaging/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_messaging.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_commsvc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_mobiledev/.npmrc
+++ b/package/zerobias/s_mobiledev/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_mobiledev/build.gradle.kts
+++ b/package/zerobias/s_mobiledev/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_mobiledev/gate-stamp.json
+++ b/package/zerobias/s_mobiledev/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "e5d94d805dcc1e26f194b6c48183baf4f7e3585ea7af483502cd99d6c7e5b1f0",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_mobiledev/index.yml
+++ b/package/zerobias/s_mobiledev/index.yml
@@ -1,0 +1,12 @@
+id: fd826573-0b37-481b-b6a9-d36cd533caf8
+name: Mobile Application Development
+description: Mobile application development services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_mobiledev-segment.svg
+code: s_mobiledev
+externalId: Mobile Application Development
+status: published
+parents:
+  - c_swdev
+tags: []
+aliases: []

--- a/package/zerobias/s_mobiledev/package.json
+++ b/package/zerobias/s_mobiledev/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_mobiledev",
+  "version": "1.0.0-rc.1",
+  "description": "Mobile application development services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_mobiledev/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_mobiledev.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_swdev": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_netsecmgmt/.npmrc
+++ b/package/zerobias/s_netsecmgmt/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_netsecmgmt/build.gradle.kts
+++ b/package/zerobias/s_netsecmgmt/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_netsecmgmt/gate-stamp.json
+++ b/package/zerobias/s_netsecmgmt/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "872b0aa8e2b7c5022ed1ecd421a820883aa18ff495122b720929381ac9684db8",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_netsecmgmt/index.yml
+++ b/package/zerobias/s_netsecmgmt/index.yml
@@ -1,0 +1,12 @@
+id: 81533a86-0dbe-4e0c-ac9f-65dc86705fd6
+name: Network Security Management
+description: Managed network security services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_netsecmgmt-segment.svg
+code: s_netsecmgmt
+externalId: Network Security Management
+status: published
+parents:
+  - c_netsec
+tags: []
+aliases: []

--- a/package/zerobias/s_netsecmgmt/package.json
+++ b/package/zerobias/s_netsecmgmt/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_netsecmgmt",
+  "version": "1.0.0-rc.1",
+  "description": "Managed network security services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_netsecmgmt/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_netsecmgmt.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_netsec": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_noc/.npmrc
+++ b/package/zerobias/s_noc/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_noc/build.gradle.kts
+++ b/package/zerobias/s_noc/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_noc/gate-stamp.json
+++ b/package/zerobias/s_noc/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "d6c31bd9342b20766afee162ef4163cf7fbda18220f388bc26e3aa7fa2b03d05",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_noc/index.yml
+++ b/package/zerobias/s_noc/index.yml
@@ -1,0 +1,12 @@
+id: 27d41502-0ba0-4bb9-ad81-95c2943b03b7
+name: Network Operations Center (NOC)
+description: Managed network monitoring and operations (NOC).
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_noc-segment.svg
+code: s_noc
+externalId: Network Operations Center (NOC)
+status: published
+parents:
+  - c_itops
+tags: []
+aliases: []

--- a/package/zerobias/s_noc/package.json
+++ b/package/zerobias/s_noc/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_noc",
+  "version": "1.0.0-rc.1",
+  "description": "Managed network monitoring and operations (NOC).",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_noc/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_noc.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_itops": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_notary/.npmrc
+++ b/package/zerobias/s_notary/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_notary/build.gradle.kts
+++ b/package/zerobias/s_notary/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_notary/gate-stamp.json
+++ b/package/zerobias/s_notary/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "7ea0df0c2d686e2131ae18cc894054102e7465f9c305459d302bde94b20db079",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_notary/index.yml
+++ b/package/zerobias/s_notary/index.yml
@@ -1,0 +1,12 @@
+id: 309b7981-b905-4489-b286-20a330fe11a3
+name: Notarization
+description: Notarization services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_notary-segment.svg
+code: s_notary
+externalId: Notarization
+status: published
+parents:
+  - c_notary
+tags: []
+aliases: []

--- a/package/zerobias/s_notary/package.json
+++ b/package/zerobias/s_notary/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_notary",
+  "version": "1.0.0-rc.1",
+  "description": "Notarization services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_notary/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_notary.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_notary": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_osha/.npmrc
+++ b/package/zerobias/s_osha/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_osha/build.gradle.kts
+++ b/package/zerobias/s_osha/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_osha/gate-stamp.json
+++ b/package/zerobias/s_osha/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "40f74adfdf9bbd0a04195280830a5c71ac592dc2427dadd49903bf15e08dc6fe",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_osha/index.yml
+++ b/package/zerobias/s_osha/index.yml
@@ -1,0 +1,12 @@
+id: 98d0ed3a-304c-42b3-b094-87c573eaa110
+name: Occupational Health and Safety
+description: Occupational health and safety (OSHA) services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_osha-segment.svg
+code: s_osha
+externalId: Occupational Health and Safety
+status: published
+parents:
+  - c_ehs
+tags: []
+aliases: []

--- a/package/zerobias/s_osha/package.json
+++ b/package/zerobias/s_osha/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_osha",
+  "version": "1.0.0-rc.1",
+  "description": "Occupational health and safety (OSHA) services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_osha/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_osha.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_ehs": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_otsec/.npmrc
+++ b/package/zerobias/s_otsec/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_otsec/build.gradle.kts
+++ b/package/zerobias/s_otsec/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_otsec/gate-stamp.json
+++ b/package/zerobias/s_otsec/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "84287caf4972cb10100af79ec5a165d4196c5a51a0c75f4be6796061b552a378",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_otsec/index.yml
+++ b/package/zerobias/s_otsec/index.yml
@@ -1,0 +1,12 @@
+id: 65509c4e-8452-459f-b495-48e6f094dd9f
+name: OT and ICS Security
+description: Operational technology and industrial control system security services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_otsec-segment.svg
+code: s_otsec
+externalId: OT and ICS Security
+status: published
+parents:
+  - c_otsec
+tags: []
+aliases: []

--- a/package/zerobias/s_otsec/package.json
+++ b/package/zerobias/s_otsec/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_otsec",
+  "version": "1.0.0-rc.1",
+  "description": "Operational technology and industrial control system security services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_otsec/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_otsec.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_otsec": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_pam/.npmrc
+++ b/package/zerobias/s_pam/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_pam/build.gradle.kts
+++ b/package/zerobias/s_pam/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_pam/gate-stamp.json
+++ b/package/zerobias/s_pam/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "d4e5fc33bb33f009f4f98761dc733604f39f902c5170ca177f66579710b7b5d1",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_pam/index.yml
+++ b/package/zerobias/s_pam/index.yml
@@ -1,0 +1,12 @@
+id: 8f76e8eb-9106-45bb-9396-fa7d2cc98f3e
+name: Privileged Access Management (PAM)
+description: Privileged access management services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_pam-segment.svg
+code: s_pam
+externalId: Privileged Access Management (PAM)
+status: published
+parents:
+  - c_idam
+tags: []
+aliases: []

--- a/package/zerobias/s_pam/package.json
+++ b/package/zerobias/s_pam/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_pam",
+  "version": "1.0.0-rc.1",
+  "description": "Privileged access management services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_pam/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_pam.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_idam": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_patchmgmt/.npmrc
+++ b/package/zerobias/s_patchmgmt/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_patchmgmt/build.gradle.kts
+++ b/package/zerobias/s_patchmgmt/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_patchmgmt/gate-stamp.json
+++ b/package/zerobias/s_patchmgmt/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "9e9aa0fe410955f41e7f36d77069c49f8dc1cbd0212064aadd4ef9054cb95e97",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_patchmgmt/index.yml
+++ b/package/zerobias/s_patchmgmt/index.yml
@@ -1,0 +1,12 @@
+id: 601bc440-18e2-4b98-90de-ab919bd821a0
+name: Patch Management
+description: Managed patch management services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_patchmgmt-segment.svg
+code: s_patchmgmt
+externalId: Patch Management
+status: published
+parents:
+  - c_itops
+tags: []
+aliases: []

--- a/package/zerobias/s_patchmgmt/package.json
+++ b/package/zerobias/s_patchmgmt/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_patchmgmt",
+  "version": "1.0.0-rc.1",
+  "description": "Managed patch management services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_patchmgmt/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_patchmgmt.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_itops": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_payroll/.npmrc
+++ b/package/zerobias/s_payroll/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_payroll/build.gradle.kts
+++ b/package/zerobias/s_payroll/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_payroll/gate-stamp.json
+++ b/package/zerobias/s_payroll/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "6fbbaf8bf5f534da41835ad831fe6e31565f9c8e1673d7125c8308806fea8292",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_payroll/index.yml
+++ b/package/zerobias/s_payroll/index.yml
@@ -1,0 +1,12 @@
+id: 6c9838a6-3f68-4339-a6f1-0bee15b6894b
+name: Payroll and Benefits Administration
+description: Payroll and benefits administration services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_payroll-segment.svg
+code: s_payroll
+externalId: Payroll and Benefits Administration
+status: published
+parents:
+  - c_hr
+tags: []
+aliases: []

--- a/package/zerobias/s_payroll/package.json
+++ b/package/zerobias/s_payroll/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_payroll",
+  "version": "1.0.0-rc.1",
+  "description": "Payroll and benefits administration services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_payroll/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_payroll.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_hr": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_payrolltax/.npmrc
+++ b/package/zerobias/s_payrolltax/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_payrolltax/build.gradle.kts
+++ b/package/zerobias/s_payrolltax/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_payrolltax/gate-stamp.json
+++ b/package/zerobias/s_payrolltax/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "27169fc5fe016c4854a14549a9b6bf21368fc9ff9d7fd6317b13a88719dc8c5b",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_payrolltax/index.yml
+++ b/package/zerobias/s_payrolltax/index.yml
@@ -1,0 +1,12 @@
+id: e7c4dd76-ae77-4bf8-8532-496a8e6c93f3
+name: Payroll Tax and Compliance
+description: Payroll tax and compliance services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_payrolltax-segment.svg
+code: s_payrolltax
+externalId: Payroll Tax and Compliance
+status: published
+parents:
+  - c_tax
+tags: []
+aliases: []

--- a/package/zerobias/s_payrolltax/package.json
+++ b/package/zerobias/s_payrolltax/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_payrolltax",
+  "version": "1.0.0-rc.1",
+  "description": "Payroll tax and compliance services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_payrolltax/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_payrolltax.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_tax": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_pentest/.npmrc
+++ b/package/zerobias/s_pentest/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_pentest/build.gradle.kts
+++ b/package/zerobias/s_pentest/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_pentest/gate-stamp.json
+++ b/package/zerobias/s_pentest/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "5a3db7676d9c1d5061732f93cda7080586d0c8d10c2f63424ad9e46d4cbf63f6",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_pentest/index.yml
+++ b/package/zerobias/s_pentest/index.yml
@@ -1,0 +1,12 @@
+id: 6082dcbd-ba8b-4fcf-b78f-bd74398ed190
+name: Penetration Testing
+description: Penetration testing and offensive security assessment services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_pentest-segment.svg
+code: s_pentest
+externalId: Penetration Testing
+status: published
+parents:
+  - c_secasmt
+tags: []
+aliases: []

--- a/package/zerobias/s_pentest/package.json
+++ b/package/zerobias/s_pentest/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_pentest",
+  "version": "1.0.0-rc.1",
+  "description": "Penetration testing and offensive security assessment services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_pentest/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_pentest.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_secasmt": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_permitting/.npmrc
+++ b/package/zerobias/s_permitting/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_permitting/build.gradle.kts
+++ b/package/zerobias/s_permitting/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_permitting/gate-stamp.json
+++ b/package/zerobias/s_permitting/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "4fa29bf50a1cca78f443a532947ad56715398d7819b839d194c6e988d91f7e1a",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_permitting/index.yml
+++ b/package/zerobias/s_permitting/index.yml
@@ -1,0 +1,12 @@
+id: ba4a4a91-72d6-4ae7-a08c-9c432c1e2db9
+name: Permitting and Licensing
+description: Permitting and licensing services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_permitting-segment.svg
+code: s_permitting
+externalId: Permitting and Licensing
+status: published
+parents:
+  - c_regapproval
+tags: []
+aliases: []

--- a/package/zerobias/s_permitting/package.json
+++ b/package/zerobias/s_permitting/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_permitting",
+  "version": "1.0.0-rc.1",
+  "description": "Permitting and licensing services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_permitting/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_permitting.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_regapproval": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_physsec/.npmrc
+++ b/package/zerobias/s_physsec/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_physsec/build.gradle.kts
+++ b/package/zerobias/s_physsec/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_physsec/gate-stamp.json
+++ b/package/zerobias/s_physsec/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "640d8d3e3a4a7611266050ce65e37b1bb416a7230c5a51389e13acefe8712377",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_physsec/index.yml
+++ b/package/zerobias/s_physsec/index.yml
@@ -1,0 +1,12 @@
+id: 46d52984-7e28-482d-926f-0689ac57522b
+name: Physical Security Assessment
+description: Physical security assessment services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_physsec-segment.svg
+code: s_physsec
+externalId: Physical Security Assessment
+status: published
+parents:
+  - c_physical
+tags: []
+aliases: []

--- a/package/zerobias/s_physsec/package.json
+++ b/package/zerobias/s_physsec/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_physsec",
+  "version": "1.0.0-rc.1",
+  "description": "Physical security assessment services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_physsec/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_physsec.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_physical": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_pki/.npmrc
+++ b/package/zerobias/s_pki/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_pki/build.gradle.kts
+++ b/package/zerobias/s_pki/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_pki/gate-stamp.json
+++ b/package/zerobias/s_pki/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "75695b38138b67b91bde1a58a54f7f3aa2b939d964fb9431fa2fe8d22a47d7b7",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_pki/index.yml
+++ b/package/zerobias/s_pki/index.yml
@@ -1,0 +1,12 @@
+id: 94be7e54-eeaa-4146-9bc5-dd972fbbc449
+name: Key Management and PKI
+description: Key management and public key infrastructure services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_pki-segment.svg
+code: s_pki
+externalId: Key Management and PKI
+status: published
+parents:
+  - c_crypto
+tags: []
+aliases: []

--- a/package/zerobias/s_pki/package.json
+++ b/package/zerobias/s_pki/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_pki",
+  "version": "1.0.0-rc.1",
+  "description": "Key management and public key infrastructure services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_pki/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_pki.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_crypto": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_pmo/.npmrc
+++ b/package/zerobias/s_pmo/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_pmo/build.gradle.kts
+++ b/package/zerobias/s_pmo/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_pmo/gate-stamp.json
+++ b/package/zerobias/s_pmo/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "710102d45acfe3066ef9d828112bdbfb1c5380749c2a187b3bb1e597b093feb8",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_pmo/index.yml
+++ b/package/zerobias/s_pmo/index.yml
@@ -1,0 +1,12 @@
+id: ebdc516c-16ee-40d2-9417-bdb6febccdae
+name: Project Management and PMO
+description: Project management and PMO services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_pmo-segment.svg
+code: s_pmo
+externalId: Project Management and PMO
+status: published
+parents:
+  - c_pmo
+tags: []
+aliases: []

--- a/package/zerobias/s_pmo/package.json
+++ b/package/zerobias/s_pmo/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_pmo",
+  "version": "1.0.0-rc.1",
+  "description": "Project management and PMO services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_pmo/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_pmo.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_pmo": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_policy/.npmrc
+++ b/package/zerobias/s_policy/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_policy/build.gradle.kts
+++ b/package/zerobias/s_policy/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_policy/gate-stamp.json
+++ b/package/zerobias/s_policy/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "4ffefa2e1bfb61070ed9420ce534fe8e541d82c35f0d8e7b92b0c6713f26a2d1",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_policy/index.yml
+++ b/package/zerobias/s_policy/index.yml
@@ -1,0 +1,12 @@
+id: 393b84f0-7a54-419c-b21a-decd15c749b7
+name: Policy and Program Development
+description: Security policy and program development services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_policy-segment.svg
+code: s_policy
+externalId: Policy and Program Development
+status: published
+parents:
+  - c_grc
+tags: []
+aliases: []

--- a/package/zerobias/s_policy/package.json
+++ b/package/zerobias/s_policy/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_policy",
+  "version": "1.0.0-rc.1",
+  "description": "Security policy and program development services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_policy/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_policy.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_grc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_privacy/.npmrc
+++ b/package/zerobias/s_privacy/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_privacy/build.gradle.kts
+++ b/package/zerobias/s_privacy/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_privacy/gate-stamp.json
+++ b/package/zerobias/s_privacy/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "c0581dd99b3199933add68c8c3be01b8eb809eeb2838f8844844a71722d3a2a9",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_privacy/index.yml
+++ b/package/zerobias/s_privacy/index.yml
@@ -1,0 +1,12 @@
+id: e7ceffdc-4739-44da-9232-7b66748c91e0
+name: Data Privacy Consulting
+description: Data privacy consulting services (GDPR, CCPA).
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_privacy-segment.svg
+code: s_privacy
+externalId: Data Privacy Consulting
+status: published
+parents:
+  - c_dataprivacy
+tags: []
+aliases: []

--- a/package/zerobias/s_privacy/package.json
+++ b/package/zerobias/s_privacy/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_privacy",
+  "version": "1.0.0-rc.1",
+  "description": "Data privacy consulting services (GDPR, CCPA).",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_privacy/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_privacy.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_dataprivacy": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_privacylaw/.npmrc
+++ b/package/zerobias/s_privacylaw/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_privacylaw/build.gradle.kts
+++ b/package/zerobias/s_privacylaw/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_privacylaw/gate-stamp.json
+++ b/package/zerobias/s_privacylaw/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "9c393fbf9717dd1af1931631b4b8c0abfd7a2858ee53763765e351555decf3e7",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_privacylaw/index.yml
+++ b/package/zerobias/s_privacylaw/index.yml
@@ -1,0 +1,12 @@
+id: acac96f4-beae-4a9a-8ed7-b35e44bfcc5e
+name: Privacy and Data Protection Law
+description: Privacy and data protection legal services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_privacylaw-segment.svg
+code: s_privacylaw
+externalId: Privacy and Data Protection Law
+status: published
+parents:
+  - c_legal
+tags: []
+aliases: []

--- a/package/zerobias/s_privacylaw/package.json
+++ b/package/zerobias/s_privacylaw/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_privacylaw",
+  "version": "1.0.0-rc.1",
+  "description": "Privacy and data protection legal services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_privacylaw/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_privacylaw.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_legal": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_prodcert/.npmrc
+++ b/package/zerobias/s_prodcert/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_prodcert/build.gradle.kts
+++ b/package/zerobias/s_prodcert/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_prodcert/gate-stamp.json
+++ b/package/zerobias/s_prodcert/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "036be99d2b5f44009f9b8ccffdbab435b0e55ae747fabf11c4202112e5c43f79",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_prodcert/index.yml
+++ b/package/zerobias/s_prodcert/index.yml
@@ -1,0 +1,12 @@
+id: 70e7e778-8f7a-40f6-86d6-0477f5be90cb
+name: Product Certification
+description: Product certification services (CE, UL, FCC).
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_prodcert-segment.svg
+code: s_prodcert
+externalId: Product Certification
+status: published
+parents:
+  - c_regapproval
+tags: []
+aliases: []

--- a/package/zerobias/s_prodcert/package.json
+++ b/package/zerobias/s_prodcert/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_prodcert",
+  "version": "1.0.0-rc.1",
+  "description": "Product certification services (CE, UL, FCC).",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_prodcert/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_prodcert.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_regapproval": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_prodval/.npmrc
+++ b/package/zerobias/s_prodval/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_prodval/build.gradle.kts
+++ b/package/zerobias/s_prodval/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_prodval/gate-stamp.json
+++ b/package/zerobias/s_prodval/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "344e5b76078758b04355411e24d548373c2e456164d87d742a62b4f79fffa45f",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_prodval/index.yml
+++ b/package/zerobias/s_prodval/index.yml
@@ -1,0 +1,12 @@
+id: 672d0310-e202-4781-a8f9-6740df1d77ea
+name: Product Validation and Testing
+description: Product validation and testing services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_prodval-segment.svg
+code: s_prodval
+externalId: Product Validation and Testing
+status: published
+parents:
+  - c_validation
+tags: []
+aliases: []

--- a/package/zerobias/s_prodval/package.json
+++ b/package/zerobias/s_prodval/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_prodval",
+  "version": "1.0.0-rc.1",
+  "description": "Product validation and testing services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_prodval/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_prodval.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_validation": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_progmgmt/.npmrc
+++ b/package/zerobias/s_progmgmt/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_progmgmt/build.gradle.kts
+++ b/package/zerobias/s_progmgmt/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_progmgmt/gate-stamp.json
+++ b/package/zerobias/s_progmgmt/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "29b7d4d62465dc3cf0195310b172533f1067898efda1ee0554399ea44544e3f8",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_progmgmt/index.yml
+++ b/package/zerobias/s_progmgmt/index.yml
@@ -1,0 +1,12 @@
+id: 786b7858-61a7-4689-b8f3-0a65c649e315
+name: Program Management
+description: Program management services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_progmgmt-segment.svg
+code: s_progmgmt
+externalId: Program Management
+status: published
+parents:
+  - c_pmo
+tags: []
+aliases: []

--- a/package/zerobias/s_progmgmt/package.json
+++ b/package/zerobias/s_progmgmt/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_progmgmt",
+  "version": "1.0.0-rc.1",
+  "description": "Program management services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_progmgmt/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_progmgmt.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_pmo": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_proposalwriting/.npmrc
+++ b/package/zerobias/s_proposalwriting/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_proposalwriting/build.gradle.kts
+++ b/package/zerobias/s_proposalwriting/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_proposalwriting/gate-stamp.json
+++ b/package/zerobias/s_proposalwriting/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "afd9826041ed2f33b1c24af3c4968be297223cf5b33aaedbeff1f2ba15b1aab2",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_proposalwriting/index.yml
+++ b/package/zerobias/s_proposalwriting/index.yml
@@ -1,0 +1,12 @@
+id: 8172b196-9cfb-41cc-82da-91790ade61ed
+name: Proposal and RFP Writing
+description: Proposal and RFP writing services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_proposalwriting-segment.svg
+code: s_proposalwriting
+externalId: Proposal and RFP Writing
+status: published
+parents:
+  - c_procurement
+tags: []
+aliases: []

--- a/package/zerobias/s_proposalwriting/package.json
+++ b/package/zerobias/s_proposalwriting/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_proposalwriting",
+  "version": "1.0.0-rc.1",
+  "description": "Proposal and RFP writing services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_proposalwriting/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_proposalwriting.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_procurement": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_qms/.npmrc
+++ b/package/zerobias/s_qms/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_qms/build.gradle.kts
+++ b/package/zerobias/s_qms/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_qms/gate-stamp.json
+++ b/package/zerobias/s_qms/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "06da5cb47d798ceff69c2a89be3e10f5362736c32039dbdd05bc143124603fa2",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_qms/index.yml
+++ b/package/zerobias/s_qms/index.yml
@@ -1,0 +1,12 @@
+id: 75f95150-1f89-43af-9732-4829a9dc1958
+name: Quality Management Systems
+description: Quality management systems services (ISO 9001).
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_qms-segment.svg
+code: s_qms
+externalId: Quality Management Systems
+status: published
+parents:
+  - c_validation
+tags: []
+aliases: []

--- a/package/zerobias/s_qms/package.json
+++ b/package/zerobias/s_qms/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_qms",
+  "version": "1.0.0-rc.1",
+  "description": "Quality management systems services (ISO 9001).",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_qms/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_qms.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_validation": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_readiness/.npmrc
+++ b/package/zerobias/s_readiness/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_readiness/build.gradle.kts
+++ b/package/zerobias/s_readiness/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_readiness/gate-stamp.json
+++ b/package/zerobias/s_readiness/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "6c0bd0abb8666dcfae78fb369174932d832c4ae1f990b4c23a4750a1e8209331",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_readiness/index.yml
+++ b/package/zerobias/s_readiness/index.yml
@@ -1,0 +1,12 @@
+id: cd2eb38f-c33c-4966-b408-952c11637e03
+name: Framework Readiness Assessment
+description: Framework readiness assessment services (CMMC, FedRAMP).
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_readiness-segment.svg
+code: s_readiness
+externalId: Framework Readiness Assessment
+status: published
+parents:
+  - c_audit
+tags: []
+aliases: []

--- a/package/zerobias/s_readiness/package.json
+++ b/package/zerobias/s_readiness/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_readiness",
+  "version": "1.0.0-rc.1",
+  "description": "Framework readiness assessment services (CMMC, FedRAMP).",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_readiness/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_readiness.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_audit": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_redteam/.npmrc
+++ b/package/zerobias/s_redteam/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_redteam/build.gradle.kts
+++ b/package/zerobias/s_redteam/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_redteam/gate-stamp.json
+++ b/package/zerobias/s_redteam/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "c5fabffad188822914af75b99e2e2e660e70bab721f204a273597f7f81342496",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_redteam/index.yml
+++ b/package/zerobias/s_redteam/index.yml
@@ -1,0 +1,12 @@
+id: 5429e2a9-8096-4eb2-bb7a-3e527ddfc07d
+name: Red Team and Adversary Emulation
+description: Red team and adversary emulation engagements.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_redteam-segment.svg
+code: s_redteam
+externalId: Red Team and Adversary Emulation
+status: published
+parents:
+  - c_secasmt
+tags: []
+aliases: []

--- a/package/zerobias/s_redteam/package.json
+++ b/package/zerobias/s_redteam/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_redteam",
+  "version": "1.0.0-rc.1",
+  "description": "Red team and adversary emulation engagements.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_redteam/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_redteam.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_secasmt": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_regcounsel/.npmrc
+++ b/package/zerobias/s_regcounsel/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_regcounsel/build.gradle.kts
+++ b/package/zerobias/s_regcounsel/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_regcounsel/gate-stamp.json
+++ b/package/zerobias/s_regcounsel/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "1bf3e92b6c5fddf149f726e8405ec2e6133a0d2e7388e1639125fb54a43ece4d",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_regcounsel/index.yml
+++ b/package/zerobias/s_regcounsel/index.yml
@@ -1,0 +1,12 @@
+id: e65150d1-2443-4d89-a5e3-a8e3c301dcfd
+name: Regulatory and Compliance Counsel
+description: Regulatory and compliance legal counsel services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_regcounsel-segment.svg
+code: s_regcounsel
+externalId: Regulatory and Compliance Counsel
+status: published
+parents:
+  - c_legal
+tags: []
+aliases: []

--- a/package/zerobias/s_regcounsel/package.json
+++ b/package/zerobias/s_regcounsel/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_regcounsel",
+  "version": "1.0.0-rc.1",
+  "description": "Regulatory and compliance legal counsel services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_regcounsel/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_regcounsel.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_legal": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_regsubmissions/.npmrc
+++ b/package/zerobias/s_regsubmissions/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_regsubmissions/build.gradle.kts
+++ b/package/zerobias/s_regsubmissions/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_regsubmissions/gate-stamp.json
+++ b/package/zerobias/s_regsubmissions/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "9f45799a057e286cf6a100a40c9fb8f832dbe0c663e17e9fd90ef7387dde6df0",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_regsubmissions/index.yml
+++ b/package/zerobias/s_regsubmissions/index.yml
@@ -1,0 +1,12 @@
+id: 322f2b69-1c0b-4811-aee6-769a1fae6274
+name: Regulatory Submissions
+description: Regulatory submission services (FDA and others).
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_regsubmissions-segment.svg
+code: s_regsubmissions
+externalId: Regulatory Submissions
+status: published
+parents:
+  - c_regapproval
+tags: []
+aliases: []

--- a/package/zerobias/s_regsubmissions/package.json
+++ b/package/zerobias/s_regsubmissions/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_regsubmissions",
+  "version": "1.0.0-rc.1",
+  "description": "Regulatory submission services (FDA and others).",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_regsubmissions/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_regsubmissions.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_regapproval": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_regtrain/.npmrc
+++ b/package/zerobias/s_regtrain/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_regtrain/build.gradle.kts
+++ b/package/zerobias/s_regtrain/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_regtrain/gate-stamp.json
+++ b/package/zerobias/s_regtrain/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "3eb6a7d94d7f20e8bebfcf6922fa1a2bfdc27ce366e3c245c8fb7e9df51459aa",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_regtrain/index.yml
+++ b/package/zerobias/s_regtrain/index.yml
@@ -1,0 +1,12 @@
+id: 860cc313-8add-40f2-a68c-a4cc05e5c47f
+name: Regulatory and Privacy Training
+description: Regulatory and privacy compliance training services (HIPAA, PCI, GDPR, and related).
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_regtrain-segment.svg
+code: s_regtrain
+externalId: Regulatory and Privacy Training
+status: published
+parents:
+  - c_train
+tags: []
+aliases: []

--- a/package/zerobias/s_regtrain/package.json
+++ b/package/zerobias/s_regtrain/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_regtrain",
+  "version": "1.0.0-rc.1",
+  "description": "Regulatory and privacy compliance training services (HIPAA, PCI, GDPR, and related).",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_regtrain/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_regtrain.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_train": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_risk/.npmrc
+++ b/package/zerobias/s_risk/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_risk/build.gradle.kts
+++ b/package/zerobias/s_risk/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_risk/gate-stamp.json
+++ b/package/zerobias/s_risk/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "81209e41875d4d150b15dc840db06d4a3dcdcfd627434795b7c1eaea410d55f1",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_risk/index.yml
+++ b/package/zerobias/s_risk/index.yml
@@ -1,0 +1,12 @@
+id: 814ea3bd-2a1f-474d-b3e5-174c8da10f80
+name: Risk Assessment
+description: Risk assessment and advisory services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_risk-segment.svg
+code: s_risk
+externalId: Risk Assessment
+status: published
+parents:
+  - c_grc
+tags: []
+aliases: []

--- a/package/zerobias/s_risk/package.json
+++ b/package/zerobias/s_risk/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_risk",
+  "version": "1.0.0-rc.1",
+  "description": "Risk assessment and advisory services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_risk/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_risk.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_grc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_safetytrain/.npmrc
+++ b/package/zerobias/s_safetytrain/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_safetytrain/build.gradle.kts
+++ b/package/zerobias/s_safetytrain/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_safetytrain/gate-stamp.json
+++ b/package/zerobias/s_safetytrain/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "a6295f0e644beb46bbca0de3fc1fee23875e9fcbe157c19b6ec571036bcedce3",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_safetytrain/index.yml
+++ b/package/zerobias/s_safetytrain/index.yml
@@ -1,0 +1,12 @@
+id: 089d1778-dbe7-4068-a52d-80f9a8516deb
+name: Health and Safety Training
+description: Health, safety, and OSHA workplace training services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_safetytrain-segment.svg
+code: s_safetytrain
+externalId: Health and Safety Training
+status: published
+parents:
+  - c_train
+tags: []
+aliases: []

--- a/package/zerobias/s_safetytrain/package.json
+++ b/package/zerobias/s_safetytrain/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_safetytrain",
+  "version": "1.0.0-rc.1",
+  "description": "Health, safety, and OSHA workplace training services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_safetytrain/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_safetytrain.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_train": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_sam/.npmrc
+++ b/package/zerobias/s_sam/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_sam/build.gradle.kts
+++ b/package/zerobias/s_sam/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_sam/gate-stamp.json
+++ b/package/zerobias/s_sam/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "fb147f4297bf224d4b39f817d34311ccd6c6b94124820fb2217efbe260a5cb15",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_sam/index.yml
+++ b/package/zerobias/s_sam/index.yml
@@ -1,0 +1,12 @@
+id: 1eea9f2f-e895-46cb-96c9-a633151acb0e
+name: Software Asset Management
+description: Software asset and license management services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_sam-segment.svg
+code: s_sam
+externalId: Software Asset Management
+status: published
+parents:
+  - c_asset
+tags: []
+aliases: []

--- a/package/zerobias/s_sam/package.json
+++ b/package/zerobias/s_sam/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_sam",
+  "version": "1.0.0-rc.1",
+  "description": "Software asset and license management services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_sam/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_sam.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_asset": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_sanctions/.npmrc
+++ b/package/zerobias/s_sanctions/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_sanctions/build.gradle.kts
+++ b/package/zerobias/s_sanctions/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_sanctions/gate-stamp.json
+++ b/package/zerobias/s_sanctions/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "0bb68b375e9a05a4fd261c77e80d804ee2996ef4abe67add732c37b7aa63f139",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_sanctions/index.yml
+++ b/package/zerobias/s_sanctions/index.yml
@@ -1,0 +1,12 @@
+id: 520ca6a0-e9f6-48eb-911a-59ece0c55275
+name: Sanctions Screening
+description: Sanctions screening services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_sanctions-segment.svg
+code: s_sanctions
+externalId: Sanctions Screening
+status: published
+parents:
+  - c_fincrime
+tags: []
+aliases: []

--- a/package/zerobias/s_sanctions/package.json
+++ b/package/zerobias/s_sanctions/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_sanctions",
+  "version": "1.0.0-rc.1",
+  "description": "Sanctions screening services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_sanctions/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_sanctions.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_fincrime": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_secarch/.npmrc
+++ b/package/zerobias/s_secarch/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_secarch/build.gradle.kts
+++ b/package/zerobias/s_secarch/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_secarch/gate-stamp.json
+++ b/package/zerobias/s_secarch/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "e09512408ad36ce611db0e6465a4f351539865bb731041038122ce9461f94b38",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_secarch/index.yml
+++ b/package/zerobias/s_secarch/index.yml
@@ -1,0 +1,12 @@
+id: 6b47d61e-0e21-47e9-90df-21e6a46b0d07
+name: Security Architecture Review
+description: Security architecture design and review services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_secarch-segment.svg
+code: s_secarch
+externalId: Security Architecture Review
+status: published
+parents:
+  - c_secasmt
+tags: []
+aliases: []

--- a/package/zerobias/s_secarch/package.json
+++ b/package/zerobias/s_secarch/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_secarch",
+  "version": "1.0.0-rc.1",
+  "description": "Security architecture design and review services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_secarch/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_secarch.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_secasmt": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_securecode/.npmrc
+++ b/package/zerobias/s_securecode/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_securecode/build.gradle.kts
+++ b/package/zerobias/s_securecode/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_securecode/gate-stamp.json
+++ b/package/zerobias/s_securecode/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "ebfa97f2ff2e0c998854737a0f8aa594dd4525eeec85a7da39edb73f464c65be",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_securecode/index.yml
+++ b/package/zerobias/s_securecode/index.yml
@@ -1,0 +1,12 @@
+id: bd3e1dfc-44f9-4f8d-99f1-4203828c831f
+name: Secure Coding and Developer Security Training
+description: Secure coding and developer security training services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_securecode-segment.svg
+code: s_securecode
+externalId: Secure Coding and Developer Security Training
+status: published
+parents:
+  - c_train
+tags: []
+aliases: []

--- a/package/zerobias/s_securecode/package.json
+++ b/package/zerobias/s_securecode/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_securecode",
+  "version": "1.0.0-rc.1",
+  "description": "Secure coding and developer security training services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_securecode/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_securecode.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_train": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_setaside/.npmrc
+++ b/package/zerobias/s_setaside/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_setaside/build.gradle.kts
+++ b/package/zerobias/s_setaside/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_setaside/gate-stamp.json
+++ b/package/zerobias/s_setaside/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "49d8b03501fe0e4a971df810faeea4811d1bac79e0371adef546ffd948dbcc90",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_setaside/index.yml
+++ b/package/zerobias/s_setaside/index.yml
@@ -1,0 +1,12 @@
+id: 5017eaee-350a-44a2-a59f-21926205a610
+name: Set-Aside Certification
+description: Set-aside certification services (MBE, WBE, DBE, 8a).
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_setaside-segment.svg
+code: s_setaside
+externalId: Set-Aside Certification
+status: published
+parents:
+  - c_bizcert
+tags: []
+aliases: []

--- a/package/zerobias/s_setaside/package.json
+++ b/package/zerobias/s_setaside/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_setaside",
+  "version": "1.0.0-rc.1",
+  "description": "Set-aside certification services (MBE, WBE, DBE, 8a).",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_setaside/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_setaside.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_bizcert": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_siemmgmt/.npmrc
+++ b/package/zerobias/s_siemmgmt/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_siemmgmt/build.gradle.kts
+++ b/package/zerobias/s_siemmgmt/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_siemmgmt/gate-stamp.json
+++ b/package/zerobias/s_siemmgmt/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "05c7228c8b0ecb278e206db70dfa5911ecc8401ba26cb7ca8d6555c4b9566617",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_siemmgmt/index.yml
+++ b/package/zerobias/s_siemmgmt/index.yml
@@ -1,0 +1,12 @@
+id: 1eb9e9b7-58ad-4f9e-b26a-bb78d5f0a401
+name: SIEM Management
+description: Managed SIEM deployment and operations.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_siemmgmt-segment.svg
+code: s_siemmgmt
+externalId: SIEM Management
+status: published
+parents:
+  - c_secops
+tags: []
+aliases: []

--- a/package/zerobias/s_siemmgmt/package.json
+++ b/package/zerobias/s_siemmgmt/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_siemmgmt",
+  "version": "1.0.0-rc.1",
+  "description": "Managed SIEM deployment and operations.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_siemmgmt/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_siemmgmt.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_secops": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_soc/.npmrc
+++ b/package/zerobias/s_soc/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_soc/build.gradle.kts
+++ b/package/zerobias/s_soc/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_soc/gate-stamp.json
+++ b/package/zerobias/s_soc/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "fc62f418037b7102f19beb4382c7e853a4071a44cc42efb626d6cab28959786b",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_soc/index.yml
+++ b/package/zerobias/s_soc/index.yml
@@ -1,0 +1,12 @@
+id: dd509c8e-5e41-4db0-9fb2-d86cdb162bd9
+name: Security Operations Center (SOC)
+description: Managed security monitoring and operations (SOC).
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_soc-segment.svg
+code: s_soc
+externalId: Security Operations Center (SOC)
+status: published
+parents:
+  - c_secops
+tags: []
+aliases: []

--- a/package/zerobias/s_soc/package.json
+++ b/package/zerobias/s_soc/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_soc",
+  "version": "1.0.0-rc.1",
+  "description": "Managed security monitoring and operations (SOC).",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_soc/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_soc.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_secops": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_staffing/.npmrc
+++ b/package/zerobias/s_staffing/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_staffing/build.gradle.kts
+++ b/package/zerobias/s_staffing/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_staffing/gate-stamp.json
+++ b/package/zerobias/s_staffing/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "cfcf0674ce4b4fec397b08c5259f4dd0543108d84e8e8432fd62dacc22c2540b",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_staffing/index.yml
+++ b/package/zerobias/s_staffing/index.yml
@@ -1,0 +1,12 @@
+id: 518c74d5-cade-47a3-a1a3-c80fe98a76b8
+name: Staffing and Recruiting
+description: Staffing and recruiting services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_staffing-segment.svg
+code: s_staffing
+externalId: Staffing and Recruiting
+status: published
+parents:
+  - c_hr
+tags: []
+aliases: []

--- a/package/zerobias/s_staffing/package.json
+++ b/package/zerobias/s_staffing/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_staffing",
+  "version": "1.0.0-rc.1",
+  "description": "Staffing and recruiting services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_staffing/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_staffing.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_hr": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_strategy/.npmrc
+++ b/package/zerobias/s_strategy/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_strategy/build.gradle.kts
+++ b/package/zerobias/s_strategy/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_strategy/gate-stamp.json
+++ b/package/zerobias/s_strategy/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "9e96e9edf42fbf4c91af1bc3c878b28a87378df3ff6cdeb90c2436fccc0a5d23",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_strategy/index.yml
+++ b/package/zerobias/s_strategy/index.yml
@@ -1,0 +1,12 @@
+id: 1106eb7a-52b3-4b40-ad54-c6d83cb86802
+name: Management and Strategy Consulting
+description: Management and strategy consulting services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_strategy-segment.svg
+code: s_strategy
+externalId: Management and Strategy Consulting
+status: published
+parents:
+  - c_advisory
+tags: []
+aliases: []

--- a/package/zerobias/s_strategy/package.json
+++ b/package/zerobias/s_strategy/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_strategy",
+  "version": "1.0.0-rc.1",
+  "description": "Management and strategy consulting services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_strategy/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_strategy.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_advisory": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_swdev/.npmrc
+++ b/package/zerobias/s_swdev/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_swdev/build.gradle.kts
+++ b/package/zerobias/s_swdev/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_swdev/gate-stamp.json
+++ b/package/zerobias/s_swdev/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "56799226fdd6a00f159a5535ecbc2dc2c8f0cf4e47f813acbf20ef32b93e79fa",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_swdev/index.yml
+++ b/package/zerobias/s_swdev/index.yml
@@ -1,0 +1,12 @@
+id: ef2b2a1b-ed56-47e2-acec-2d1455349cc8
+name: Custom Software Development
+description: Custom software development services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_swdev-segment.svg
+code: s_swdev
+externalId: Custom Software Development
+status: published
+parents:
+  - c_swdev
+tags: []
+aliases: []

--- a/package/zerobias/s_swdev/package.json
+++ b/package/zerobias/s_swdev/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_swdev",
+  "version": "1.0.0-rc.1",
+  "description": "Custom software development services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_swdev/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_swdev.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_swdev": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_swtest/.npmrc
+++ b/package/zerobias/s_swtest/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_swtest/build.gradle.kts
+++ b/package/zerobias/s_swtest/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_swtest/gate-stamp.json
+++ b/package/zerobias/s_swtest/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "3e17a00ecc1c6db0f580ae99deb075facf48721be116541f2622366559604a8e",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_swtest/index.yml
+++ b/package/zerobias/s_swtest/index.yml
@@ -1,0 +1,12 @@
+id: 78ca4555-956c-4fc5-8304-cf7e639c5b7a
+name: QA and Software Testing
+description: Software quality assurance and testing services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_swtest-segment.svg
+code: s_swtest
+externalId: QA and Software Testing
+status: published
+parents:
+  - c_swdev
+tags: []
+aliases: []

--- a/package/zerobias/s_swtest/package.json
+++ b/package/zerobias/s_swtest/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_swtest",
+  "version": "1.0.0-rc.1",
+  "description": "Software quality assurance and testing services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_swtest/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_swtest.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_swdev": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_tabletop/.npmrc
+++ b/package/zerobias/s_tabletop/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_tabletop/build.gradle.kts
+++ b/package/zerobias/s_tabletop/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_tabletop/gate-stamp.json
+++ b/package/zerobias/s_tabletop/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "e3b85634ccf90998446a60daadcaa85723614f642a57f3a79571e1352634f1f2",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_tabletop/index.yml
+++ b/package/zerobias/s_tabletop/index.yml
@@ -1,0 +1,12 @@
+id: 0ef6c7c4-ad33-46c0-9a27-7aad52525a39
+name: Tabletop Exercises
+description: Incident response tabletop exercise services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_tabletop-segment.svg
+code: s_tabletop
+externalId: Tabletop Exercises
+status: published
+parents:
+  - c_train
+tags: []
+aliases: []

--- a/package/zerobias/s_tabletop/package.json
+++ b/package/zerobias/s_tabletop/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_tabletop",
+  "version": "1.0.0-rc.1",
+  "description": "Incident response tabletop exercise services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_tabletop/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_tabletop.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_train": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_taxprep/.npmrc
+++ b/package/zerobias/s_taxprep/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_taxprep/build.gradle.kts
+++ b/package/zerobias/s_taxprep/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_taxprep/gate-stamp.json
+++ b/package/zerobias/s_taxprep/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "584024b3644aeb0ac6b8b55a5fc274c50f312f83269dc63e314669c75ebc46a3",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_taxprep/index.yml
+++ b/package/zerobias/s_taxprep/index.yml
@@ -1,0 +1,12 @@
+id: f0167f54-8eb2-47e8-bad8-2b434d7bc113
+name: Tax Preparation and Planning
+description: Tax preparation and planning services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_taxprep-segment.svg
+code: s_taxprep
+externalId: Tax Preparation and Planning
+status: published
+parents:
+  - c_tax
+tags: []
+aliases: []

--- a/package/zerobias/s_taxprep/package.json
+++ b/package/zerobias/s_taxprep/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_taxprep",
+  "version": "1.0.0-rc.1",
+  "description": "Tax preparation and planning services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_taxprep/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_taxprep.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_tax": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_threathunt/.npmrc
+++ b/package/zerobias/s_threathunt/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_threathunt/build.gradle.kts
+++ b/package/zerobias/s_threathunt/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_threathunt/gate-stamp.json
+++ b/package/zerobias/s_threathunt/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "c648c66ecca9514b4746346ae213656996fea3757f310c29e3f78681e42830d0",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_threathunt/index.yml
+++ b/package/zerobias/s_threathunt/index.yml
@@ -1,0 +1,12 @@
+id: 7fcddbf0-1875-4cb8-a4fa-13f7aaf911c7
+name: Threat Hunting
+description: Proactive threat hunting services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_threathunt-segment.svg
+code: s_threathunt
+externalId: Threat Hunting
+status: published
+parents:
+  - c_secops
+tags: []
+aliases: []

--- a/package/zerobias/s_threathunt/package.json
+++ b/package/zerobias/s_threathunt/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_threathunt",
+  "version": "1.0.0-rc.1",
+  "description": "Proactive threat hunting services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_threathunt/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_threathunt.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_secops": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_tprm/.npmrc
+++ b/package/zerobias/s_tprm/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_tprm/build.gradle.kts
+++ b/package/zerobias/s_tprm/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_tprm/gate-stamp.json
+++ b/package/zerobias/s_tprm/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "78ca5c69ec91ac7552d3de5685d0c28447dde0ae5e9ce5c48372d8cc5a8a8b3e",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_tprm/index.yml
+++ b/package/zerobias/s_tprm/index.yml
@@ -1,0 +1,12 @@
+id: f50c6a99-6d5b-4f94-b026-974da4573c7f
+name: Third-Party Risk Management
+description: Third-party and vendor risk management services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_tprm-segment.svg
+code: s_tprm
+externalId: Third-Party Risk Management
+status: published
+parents:
+  - c_grc
+tags: []
+aliases: []

--- a/package/zerobias/s_tprm/package.json
+++ b/package/zerobias/s_tprm/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_tprm",
+  "version": "1.0.0-rc.1",
+  "description": "Third-party and vendor risk management services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_tprm/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_tprm.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_grc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_ucaas/.npmrc
+++ b/package/zerobias/s_ucaas/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_ucaas/build.gradle.kts
+++ b/package/zerobias/s_ucaas/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_ucaas/gate-stamp.json
+++ b/package/zerobias/s_ucaas/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "892cec5820eb81f9fdb4106d6156c5d0caa1b096eda110da42ba8074d696b06f",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_ucaas/index.yml
+++ b/package/zerobias/s_ucaas/index.yml
@@ -1,0 +1,12 @@
+id: a1d48c2e-49c0-466e-9556-6512883f9271
+name: Unified Communications (UCaaS)
+description: Unified communications as a service.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_ucaas-segment.svg
+code: s_ucaas
+externalId: Unified Communications (UCaaS)
+status: published
+parents:
+  - c_commsvc
+tags: []
+aliases: []

--- a/package/zerobias/s_ucaas/package.json
+++ b/package/zerobias/s_ucaas/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_ucaas",
+  "version": "1.0.0-rc.1",
+  "description": "Unified communications as a service.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_ucaas/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_ucaas.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_commsvc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_vciso/.npmrc
+++ b/package/zerobias/s_vciso/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_vciso/build.gradle.kts
+++ b/package/zerobias/s_vciso/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_vciso/gate-stamp.json
+++ b/package/zerobias/s_vciso/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "c3b85b9fffc9dc29e29c9318e2f708b587757b4cff2623e8c998a46dc00d79f6",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_vciso/index.yml
+++ b/package/zerobias/s_vciso/index.yml
@@ -1,0 +1,12 @@
+id: 67a707c9-8e34-4d45-84f3-570d375c73f5
+name: vCISO and Security Advisory
+description: Virtual CISO and security advisory services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_vciso-segment.svg
+code: s_vciso
+externalId: vCISO and Security Advisory
+status: published
+parents:
+  - c_grc
+tags: []
+aliases: []

--- a/package/zerobias/s_vciso/package.json
+++ b/package/zerobias/s_vciso/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_vciso",
+  "version": "1.0.0-rc.1",
+  "description": "Virtual CISO and security advisory services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_vciso/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_vciso.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_grc": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_vendorreg/.npmrc
+++ b/package/zerobias/s_vendorreg/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_vendorreg/build.gradle.kts
+++ b/package/zerobias/s_vendorreg/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_vendorreg/gate-stamp.json
+++ b/package/zerobias/s_vendorreg/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "e005ede89b7a9cc7ac249ecbe06c52b4a7f94956ae8d79819b4ca72c5dff09b4",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_vendorreg/index.yml
+++ b/package/zerobias/s_vendorreg/index.yml
@@ -1,0 +1,12 @@
+id: 73ce23b4-edee-4956-86a6-954c70091278
+name: Vendor Registration and Qualification
+description: Vendor registration and qualification services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_vendorreg-segment.svg
+code: s_vendorreg
+externalId: Vendor Registration and Qualification
+status: published
+parents:
+  - c_procurement
+tags: []
+aliases: []

--- a/package/zerobias/s_vendorreg/package.json
+++ b/package/zerobias/s_vendorreg/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_vendorreg",
+  "version": "1.0.0-rc.1",
+  "description": "Vendor registration and qualification services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_vendorreg/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_vendorreg.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_procurement": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_vendorvet/.npmrc
+++ b/package/zerobias/s_vendorvet/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_vendorvet/build.gradle.kts
+++ b/package/zerobias/s_vendorvet/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_vendorvet/gate-stamp.json
+++ b/package/zerobias/s_vendorvet/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "5b81e2ab35781fe9b9c54c4955bcdafc913ae1acf7985ffe3349823cd3178617",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_vendorvet/index.yml
+++ b/package/zerobias/s_vendorvet/index.yml
@@ -1,0 +1,12 @@
+id: 13964aa4-2f4f-4c62-9e35-c712f18de033
+name: Vendor and Supplier Vetting
+description: Vendor and supplier vetting services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_vendorvet-segment.svg
+code: s_vendorvet
+externalId: Vendor and Supplier Vetting
+status: published
+parents:
+  - c_screening
+tags: []
+aliases: []

--- a/package/zerobias/s_vendorvet/package.json
+++ b/package/zerobias/s_vendorvet/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_vendorvet",
+  "version": "1.0.0-rc.1",
+  "description": "Vendor and supplier vetting services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_vendorvet/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_vendorvet.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_screening": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_vulnassess/.npmrc
+++ b/package/zerobias/s_vulnassess/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_vulnassess/build.gradle.kts
+++ b/package/zerobias/s_vulnassess/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_vulnassess/gate-stamp.json
+++ b/package/zerobias/s_vulnassess/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "75de78062f0e8c254260cb903ca8bf46b434ec1742007caa91b50b01125819ed",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_vulnassess/index.yml
+++ b/package/zerobias/s_vulnassess/index.yml
@@ -1,0 +1,12 @@
+id: 1af317da-f3a5-46f7-8945-8a1ca9d9cd8a
+name: Vulnerability Assessment
+description: Vulnerability assessment and scanning services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_vulnassess-segment.svg
+code: s_vulnassess
+externalId: Vulnerability Assessment
+status: published
+parents:
+  - c_secasmt
+tags: []
+aliases: []

--- a/package/zerobias/s_vulnassess/package.json
+++ b/package/zerobias/s_vulnassess/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_vulnassess",
+  "version": "1.0.0-rc.1",
+  "description": "Vulnerability assessment and scanning services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_vulnassess/" },
+  "scripts": {
+    "nx:publish": "../../../scripts/publish.sh",
+    "prepublishtest": "../../../scripts/prepublish.sh",
+    "correct:deps": "ts-node ../../../scripts/correctDeps.ts",
+    "validate": "ts-node ../../../scripts/validate.ts"
+  },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_vulnassess.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_secasmt": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_webdev/.npmrc
+++ b/package/zerobias/s_webdev/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_webdev/build.gradle.kts
+++ b/package/zerobias/s_webdev/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_webdev/gate-stamp.json
+++ b/package/zerobias/s_webdev/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "a22f8403fd0d4c47a2a923b5f246131a49641c28a574c5d80a7d646308be999b",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_webdev/index.yml
+++ b/package/zerobias/s_webdev/index.yml
@@ -1,0 +1,12 @@
+id: 1196e17e-16c0-4da8-9601-7e4eff9c0e24
+name: Web Application Development
+description: Web application development services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_webdev-segment.svg
+code: s_webdev
+externalId: Web Application Development
+status: published
+parents:
+  - c_swdev
+tags: []
+aliases: []

--- a/package/zerobias/s_webdev/package.json
+++ b/package/zerobias/s_webdev/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_webdev",
+  "version": "1.0.0-rc.1",
+  "description": "Web application development services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_webdev/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_webdev.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_swdev": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_workerscomp/.npmrc
+++ b/package/zerobias/s_workerscomp/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_workerscomp/build.gradle.kts
+++ b/package/zerobias/s_workerscomp/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_workerscomp/gate-stamp.json
+++ b/package/zerobias/s_workerscomp/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "aa9c09180b88b091be59c32cf21ec45f8d0da1aaaefc41e9304fb68ee8d24af2",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_workerscomp/index.yml
+++ b/package/zerobias/s_workerscomp/index.yml
@@ -1,0 +1,12 @@
+id: e7e4ec6a-ddb9-490f-ba15-0676334c2c88
+name: Workers Compensation
+description: Workers compensation services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_workerscomp-segment.svg
+code: s_workerscomp
+externalId: Workers Compensation
+status: published
+parents:
+  - c_labor
+tags: []
+aliases: []

--- a/package/zerobias/s_workerscomp/package.json
+++ b/package/zerobias/s_workerscomp/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_workerscomp",
+  "version": "1.0.0-rc.1",
+  "description": "Workers compensation services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_workerscomp/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_workerscomp.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_labor": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_workforce/.npmrc
+++ b/package/zerobias/s_workforce/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_workforce/build.gradle.kts
+++ b/package/zerobias/s_workforce/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_workforce/gate-stamp.json
+++ b/package/zerobias/s_workforce/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "a17ee60c731426189812219a3c7a4e0e451cfba0a77bc0c9cdb053589f2a8dea",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_workforce/index.yml
+++ b/package/zerobias/s_workforce/index.yml
@@ -1,0 +1,12 @@
+id: 7c5338be-a887-45ff-a49e-0f4318504773
+name: Workforce and Talent Management
+description: Workforce and talent management services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_workforce-segment.svg
+code: s_workforce
+externalId: Workforce and Talent Management
+status: published
+parents:
+  - c_hr
+tags: []
+aliases: []

--- a/package/zerobias/s_workforce/package.json
+++ b/package/zerobias/s_workforce/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_workforce",
+  "version": "1.0.0-rc.1",
+  "description": "Workforce and talent management services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_workforce/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_workforce.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_hr": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}

--- a/package/zerobias/s_zerotrust/.npmrc
+++ b/package/zerobias/s_zerotrust/.npmrc
@@ -1,0 +1,5 @@
+@auditmation:registry=https://pkg.zerobias.org
+@auditlogic:registry=https://pkg.zerobias.org
+@zerobias-org:registry=https://pkg.zerobias.org
+//pkg.zerobias.org/:always-auth=true
+//pkg.zerobias.org/:_authToken=${ZB_TOKEN}

--- a/package/zerobias/s_zerotrust/build.gradle.kts
+++ b/package/zerobias/s_zerotrust/build.gradle.kts
@@ -1,0 +1,1 @@
+plugins { id("zb.content") }

--- a/package/zerobias/s_zerotrust/gate-stamp.json
+++ b/package/zerobias/s_zerotrust/gate-stamp.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-uat.0",
+  "branch": "feat/service-segments-l2-services",
+  "sourceHash": "1d86369b2eef3bc57ddee33515bf5fc4b827a3334bfc9d465c9ecd3ee63d34c9",
+  "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "tasks": {
+    "validate": "passed",
+    "lint": "passed",
+    "compile": "passed",
+    "test": "passed",
+    "testDirect": "passed",
+    "testDocker": "passed",
+    "testDataloader": "passed",
+    "buildArtifacts": "passed"
+  },
+  "tests": {
+      "unit": { "expected": 0, "ran": 0, "status": "skipped" },
+      "integration": { "expected": 0, "ran": 0, "status": "skipped" },
+      "e2e": { "expected": 0, "ran": 0, "status": "skipped" }
+  }
+}

--- a/package/zerobias/s_zerotrust/index.yml
+++ b/package/zerobias/s_zerotrust/index.yml
@@ -1,0 +1,12 @@
+id: ab53d006-5e16-404e-a114-54bb4d72c098
+name: Zero Trust and Segmentation
+description: Zero trust architecture and network segmentation services.
+segmentType: service
+imageUrl: https://cdn.auditmation.io/logos/zerobias-s_zerotrust-segment.svg
+code: s_zerotrust
+externalId: Zero Trust and Segmentation
+status: published
+parents:
+  - c_netsec
+tags: []
+aliases: []

--- a/package/zerobias/s_zerotrust/package.json
+++ b/package/zerobias/s_zerotrust/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@zerobias-org/segment-zerobias-s_zerotrust",
+  "version": "1.0.0-rc.1",
+  "description": "Zero trust architecture and network segmentation services.",
+  "author": "team@zerobias.com",
+  "license": "ISC",
+  "repository": { "type": "git", "url": "git@github.com:zerobias-org/segment.git", "directory": "package/zerobias/s_zerotrust/" },
+  "scripts": { "nx:publish": "../../../scripts/publish.sh", "prepublishtest": "../../../scripts/prepublish.sh", "correct:deps": "ts-node ../../../scripts/correctDeps.ts", "validate": "ts-node ../../../scripts/validate.ts" },
+  "publishConfig": { "registry": "https://npm.pkg.github.com/" },
+  "files": [ "index.yml" ],
+  "auditmation": { "dataloader-version": "3.29.26", "import-artifact": "segment", "package": "zerobias.s_zerotrust.segment" },
+  "dependencies": {
+    "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/segment-zerobias-c_netsec": "latest",
+    "@zerobias-org/segment_type-zerobias": "latest"
+  }
+}


### PR DESCRIPTION
Level 2 (leaf level) of the Services taxonomy: the 131 service segments under the 37 categories (published as #29).

Per Chris (no inside-dep publishing - parents publish before children): the categories landed first, so each service resolves its segment-zerobias-c_*@latest parent.

All 131 gated GREEN (slot-less, remote dataloader-service); each ships its gate-stamp.json with 131 distinct sourceHashes. This completes the 169-package Services taxonomy (1 domain + 37 categories + 131 services).

@danielrojas-nf - final level of the rollout, ready to merge when you are.