### PR TITLE
feat(segment): wire dev-tooling features into c_vcs, t_aica, t_sca, t_vchp

### DIFF
--- a/package/zerobias/c_vcs/gate-stamp.json
+++ b/package/zerobias/c_vcs/gate-stamp.json
@@ -1,7 +1,7 @@
 {
   "version": "2.0.0-uat.0",
-  "branch": "chore/bootstrap-gradle-zbb",
-  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "branch": "feat/github-segment-features",
+  "sourceHash": "2943dd555fde9824cdb94c231f5a7a7e51854c325f1170ccbedc61a0c4f620d9",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {
     "validate": "passed",

--- a/package/zerobias/c_vcs/npm-shrinkwrap.json
+++ b/package/zerobias/c_vcs/npm-shrinkwrap.json
@@ -1,15 +1,19 @@
 {
   "name": "@zerobias-org/segment-zerobias-c_vcs",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerobias-org/segment-zerobias-c_vcs",
-      "version": "1.0.2",
+      "version": "2.0.0",
       "license": "ISC",
       "dependencies": {
         "@auditlogic/vendor-zerobias": "latest",
+        "@zerobias-org/compliance_feature-zerobias-f_cbam": "latest",
+        "@zerobias-org/compliance_feature-zerobias-f_cvm2": "latest",
+        "@zerobias-org/compliance_feature-zerobias-f_rc": "latest",
+        "@zerobias-org/compliance_feature-zerobias-f_vhad": "latest",
         "@zerobias-org/segment_type-zerobias": "latest",
         "@zerobias-org/segment-zerobias-d_sd": "latest"
       }
@@ -18,6 +22,42 @@
       "version": "1.0.0",
       "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
       "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/compliance_feature-zerobias-f_cbam": {
+      "version": "2.0.0",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/compliance_feature-zerobias-f_cbam/-/compliance_feature-zerobias-f_cbam-2.0.0.tgz",
+      "integrity": "sha512-6ijh3YJHtMO4z8X7ni+JhtCYmVOoX4i4IF/VcSId9qLzg+448lkLpLYBZq7Ix/psPh/rMJnpkvye4KMRA4/RYw==",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "latest"
+      }
+    },
+    "node_modules/@zerobias-org/compliance_feature-zerobias-f_cvm2": {
+      "version": "2.0.0",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/compliance_feature-zerobias-f_cvm2/-/compliance_feature-zerobias-f_cvm2-2.0.0.tgz",
+      "integrity": "sha512-LxKC4kthsknERlxClDBbC5iDfp03bUogqTQp2IIVHxy0+tAg77u0lIuvS+H5D4cWkdv+cBn0pnI89AjJOWc6VQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "latest"
+      }
+    },
+    "node_modules/@zerobias-org/compliance_feature-zerobias-f_rc": {
+      "version": "2.0.0",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/compliance_feature-zerobias-f_rc/-/compliance_feature-zerobias-f_rc-2.0.0.tgz",
+      "integrity": "sha512-nXO01Ed9nrWOKb5K1whaLjvggJ6/erLDfcamgcmNpyhyrokI7dfwT2Ex5X3rFMXqXSAjGYd6BlHpj18AJ77U5g==",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "latest"
+      }
+    },
+    "node_modules/@zerobias-org/compliance_feature-zerobias-f_vhad": {
+      "version": "2.0.0",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/compliance_feature-zerobias-f_vhad/-/compliance_feature-zerobias-f_vhad-2.0.0.tgz",
+      "integrity": "sha512-TdfRHXkne/esjJlKQ0kyJtptXD2uDxElX6pMyektLTO4z2MEOWlv+GGTO88rY6sVnDaB/OjC/j+Ia30pFMxziw==",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "latest"
+      }
     },
     "node_modules/@zerobias-org/segment_type-zerobias": {
       "version": "1.0.15",
@@ -42,6 +82,38 @@
       "version": "1.0.0",
       "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
       "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "@zerobias-org/compliance_feature-zerobias-f_cbam": {
+      "version": "2.0.0",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/compliance_feature-zerobias-f_cbam/-/compliance_feature-zerobias-f_cbam-2.0.0.tgz",
+      "integrity": "sha512-6ijh3YJHtMO4z8X7ni+JhtCYmVOoX4i4IF/VcSId9qLzg+448lkLpLYBZq7Ix/psPh/rMJnpkvye4KMRA4/RYw==",
+      "requires": {
+        "@auditlogic/vendor-zerobias": "latest"
+      }
+    },
+    "@zerobias-org/compliance_feature-zerobias-f_cvm2": {
+      "version": "2.0.0",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/compliance_feature-zerobias-f_cvm2/-/compliance_feature-zerobias-f_cvm2-2.0.0.tgz",
+      "integrity": "sha512-LxKC4kthsknERlxClDBbC5iDfp03bUogqTQp2IIVHxy0+tAg77u0lIuvS+H5D4cWkdv+cBn0pnI89AjJOWc6VQ==",
+      "requires": {
+        "@auditlogic/vendor-zerobias": "latest"
+      }
+    },
+    "@zerobias-org/compliance_feature-zerobias-f_rc": {
+      "version": "2.0.0",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/compliance_feature-zerobias-f_rc/-/compliance_feature-zerobias-f_rc-2.0.0.tgz",
+      "integrity": "sha512-nXO01Ed9nrWOKb5K1whaLjvggJ6/erLDfcamgcmNpyhyrokI7dfwT2Ex5X3rFMXqXSAjGYd6BlHpj18AJ77U5g==",
+      "requires": {
+        "@auditlogic/vendor-zerobias": "latest"
+      }
+    },
+    "@zerobias-org/compliance_feature-zerobias-f_vhad": {
+      "version": "2.0.0",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/compliance_feature-zerobias-f_vhad/-/compliance_feature-zerobias-f_vhad-2.0.0.tgz",
+      "integrity": "sha512-TdfRHXkne/esjJlKQ0kyJtptXD2uDxElX6pMyektLTO4z2MEOWlv+GGTO88rY6sVnDaB/OjC/j+Ia30pFMxziw==",
+      "requires": {
+        "@auditlogic/vendor-zerobias": "latest"
+      }
     },
     "@zerobias-org/segment_type-zerobias": {
       "version": "1.0.15",

--- a/package/zerobias/c_vcs/package.json
+++ b/package/zerobias/c_vcs/package.json
@@ -28,6 +28,10 @@
   },
   "dependencies": {
     "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/compliance_feature-zerobias-f_cbam": "latest",
+    "@zerobias-org/compliance_feature-zerobias-f_cvm2": "latest",
+    "@zerobias-org/compliance_feature-zerobias-f_rc": "latest",
+    "@zerobias-org/compliance_feature-zerobias-f_vhad": "latest",
     "@zerobias-org/segment-zerobias-d_sd": "latest",
     "@zerobias-org/segment_type-zerobias": "latest"
   }

--- a/package/zerobias/c_vcs/supports.yml
+++ b/package/zerobias/c_vcs/supports.yml
@@ -1,0 +1,13 @@
+supports:
+  - complianceFeature: f_cbam
+    status: supported
+    strength: high
+  - complianceFeature: f_cvm2
+    status: supported
+    strength: high
+  - complianceFeature: f_rc
+    status: supported
+    strength: high
+  - complianceFeature: f_vhad
+    status: supported
+    strength: high

--- a/package/zerobias/t_aica/gate-stamp.json
+++ b/package/zerobias/t_aica/gate-stamp.json
@@ -1,7 +1,7 @@
 {
   "version": "2.0.0-uat.0",
-  "branch": "chore/bootstrap-gradle-zbb",
-  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "branch": "feat/github-segment-features",
+  "sourceHash": "edf593ef04866e3c73c49d9964242226e759a1dc3c89e36f7b25dfe792eb9b8d",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {
     "validate": "passed",

--- a/package/zerobias/t_aica/npm-shrinkwrap.json
+++ b/package/zerobias/t_aica/npm-shrinkwrap.json
@@ -1,15 +1,20 @@
 {
   "name": "@zerobias-org/segment-zerobias-t_aica",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerobias-org/segment-zerobias-t_aica",
-      "version": "1.0.2",
+      "version": "2.0.0",
       "license": "ISC",
       "dependencies": {
         "@auditlogic/vendor-zerobias": "latest",
+        "@zerobias-org/compliance_feature-zerobias-f_aicg": "latest",
+        "@zerobias-org/compliance_feature-zerobias-f_aipf": "latest",
+        "@zerobias-org/compliance_feature-zerobias-f_atg": "latest",
+        "@zerobias-org/compliance_feature-zerobias-f_iw_des": "latest",
+        "@zerobias-org/compliance_feature-zerobias-f_iw_vcs": "latest",
         "@zerobias-org/segment_type-zerobias": "latest",
         "@zerobias-org/segment-zerobias-c_st": "latest"
       }
@@ -18,6 +23,51 @@
       "version": "1.0.0",
       "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
       "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/compliance_feature-zerobias-f_aicg": {
+      "version": "1.0.0-dev.0",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/compliance_feature-zerobias-f_aicg/-/compliance_feature-zerobias-f_aicg-1.0.0-dev.0.tgz",
+      "integrity": "sha512-fEKftoZ8lHLrXIJjD9YyKhFlolvxTt6v+ciXW9cBA2LqTc54ZMe5C0W/sFw+0fIwhKM7AWhT78g5XAI+psOXGQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "latest"
+      }
+    },
+    "node_modules/@zerobias-org/compliance_feature-zerobias-f_aipf": {
+      "version": "2.0.0",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/compliance_feature-zerobias-f_aipf/-/compliance_feature-zerobias-f_aipf-2.0.0.tgz",
+      "integrity": "sha512-0txL1g2vAPm+VFCokVrYo5nYYS47A8VQyg9/IaN6r1S7TJye5xx+lT72XqW3xK9ufw+lx+iHDOf0RP325bziLg==",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "latest"
+      }
+    },
+    "node_modules/@zerobias-org/compliance_feature-zerobias-f_atg": {
+      "version": "2.0.0",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/compliance_feature-zerobias-f_atg/-/compliance_feature-zerobias-f_atg-2.0.0.tgz",
+      "integrity": "sha512-m+jDEoXTvuobCzWV6U4JdDoK6HheDg0ok6femIT15+caANP6wwBqWLKDdxNZfrRZ/ziGZpkzePPRGm6p103ggA==",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "latest"
+      }
+    },
+    "node_modules/@zerobias-org/compliance_feature-zerobias-f_iw_des": {
+      "version": "2.0.0",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/compliance_feature-zerobias-f_iw_des/-/compliance_feature-zerobias-f_iw_des-2.0.0.tgz",
+      "integrity": "sha512-NUls6Gv+yDiYtiUAIKQ3BAjgnrWyruGXfitkES6sfoxsg1FqE3xCd5V/x6Rq4kjE/QKK6WrkmOejdekVFEfLWA==",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "latest"
+      }
+    },
+    "node_modules/@zerobias-org/compliance_feature-zerobias-f_iw_vcs": {
+      "version": "2.0.0",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/compliance_feature-zerobias-f_iw_vcs/-/compliance_feature-zerobias-f_iw_vcs-2.0.0.tgz",
+      "integrity": "sha512-7zizElcmbrZkpdLYY7CGU7O2jYPyhXmf9zv+6EufBkv/u72Q3ABE8fBzIYJhkYSK4UcaypFx7lMdY+yDMMxBWA==",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "latest"
+      }
     },
     "node_modules/@zerobias-org/segment_type-zerobias": {
       "version": "1.0.15",
@@ -52,6 +102,46 @@
       "version": "1.0.0",
       "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
       "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "@zerobias-org/compliance_feature-zerobias-f_aicg": {
+      "version": "1.0.0-dev.0",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/compliance_feature-zerobias-f_aicg/-/compliance_feature-zerobias-f_aicg-1.0.0-dev.0.tgz",
+      "integrity": "sha512-fEKftoZ8lHLrXIJjD9YyKhFlolvxTt6v+ciXW9cBA2LqTc54ZMe5C0W/sFw+0fIwhKM7AWhT78g5XAI+psOXGQ==",
+      "requires": {
+        "@auditlogic/vendor-zerobias": "latest"
+      }
+    },
+    "@zerobias-org/compliance_feature-zerobias-f_aipf": {
+      "version": "2.0.0",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/compliance_feature-zerobias-f_aipf/-/compliance_feature-zerobias-f_aipf-2.0.0.tgz",
+      "integrity": "sha512-0txL1g2vAPm+VFCokVrYo5nYYS47A8VQyg9/IaN6r1S7TJye5xx+lT72XqW3xK9ufw+lx+iHDOf0RP325bziLg==",
+      "requires": {
+        "@auditlogic/vendor-zerobias": "latest"
+      }
+    },
+    "@zerobias-org/compliance_feature-zerobias-f_atg": {
+      "version": "2.0.0",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/compliance_feature-zerobias-f_atg/-/compliance_feature-zerobias-f_atg-2.0.0.tgz",
+      "integrity": "sha512-m+jDEoXTvuobCzWV6U4JdDoK6HheDg0ok6femIT15+caANP6wwBqWLKDdxNZfrRZ/ziGZpkzePPRGm6p103ggA==",
+      "requires": {
+        "@auditlogic/vendor-zerobias": "latest"
+      }
+    },
+    "@zerobias-org/compliance_feature-zerobias-f_iw_des": {
+      "version": "2.0.0",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/compliance_feature-zerobias-f_iw_des/-/compliance_feature-zerobias-f_iw_des-2.0.0.tgz",
+      "integrity": "sha512-NUls6Gv+yDiYtiUAIKQ3BAjgnrWyruGXfitkES6sfoxsg1FqE3xCd5V/x6Rq4kjE/QKK6WrkmOejdekVFEfLWA==",
+      "requires": {
+        "@auditlogic/vendor-zerobias": "latest"
+      }
+    },
+    "@zerobias-org/compliance_feature-zerobias-f_iw_vcs": {
+      "version": "2.0.0",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/compliance_feature-zerobias-f_iw_vcs/-/compliance_feature-zerobias-f_iw_vcs-2.0.0.tgz",
+      "integrity": "sha512-7zizElcmbrZkpdLYY7CGU7O2jYPyhXmf9zv+6EufBkv/u72Q3ABE8fBzIYJhkYSK4UcaypFx7lMdY+yDMMxBWA==",
+      "requires": {
+        "@auditlogic/vendor-zerobias": "latest"
+      }
     },
     "@zerobias-org/segment_type-zerobias": {
       "version": "1.0.15",

--- a/package/zerobias/t_aica/package.json
+++ b/package/zerobias/t_aica/package.json
@@ -28,6 +28,11 @@
   },
   "dependencies": {
     "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/compliance_feature-zerobias-f_aicg": "latest",
+    "@zerobias-org/compliance_feature-zerobias-f_aipf": "latest",
+    "@zerobias-org/compliance_feature-zerobias-f_atg": "latest",
+    "@zerobias-org/compliance_feature-zerobias-f_iw_des": "latest",
+    "@zerobias-org/compliance_feature-zerobias-f_iw_vcs": "latest",
     "@zerobias-org/segment-zerobias-c_st": "latest",
     "@zerobias-org/segment_type-zerobias": "latest"
   }

--- a/package/zerobias/t_aica/supports.yml
+++ b/package/zerobias/t_aica/supports.yml
@@ -1,0 +1,16 @@
+supports:
+  - complianceFeature: f_aicg
+    status: supported
+    strength: high
+  - complianceFeature: f_aipf
+    status: supported
+    strength: high
+  - complianceFeature: f_atg
+    status: supported
+    strength: medium
+  - complianceFeature: f_iw_des
+    status: supported
+    strength: high
+  - complianceFeature: f_iw_vcs
+    status: supported
+    strength: medium

--- a/package/zerobias/t_sca/gate-stamp.json
+++ b/package/zerobias/t_sca/gate-stamp.json
@@ -1,7 +1,7 @@
 {
   "version": "2.0.0-uat.0",
-  "branch": "chore/bootstrap-gradle-zbb",
-  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "branch": "feat/github-segment-features",
+  "sourceHash": "6f49a853ff678d38b5f50695ee42d1f78edd4711d92a800c35b21e6860beda6c",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {
     "validate": "passed",

--- a/package/zerobias/t_sca/npm-shrinkwrap.json
+++ b/package/zerobias/t_sca/npm-shrinkwrap.json
@@ -1,15 +1,24 @@
 {
   "name": "@zerobias-org/segment-zerobias-t_sca",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerobias-org/segment-zerobias-t_sca",
-      "version": "1.0.4",
+      "version": "2.0.0",
       "license": "ISC",
       "dependencies": {
         "@auditlogic/vendor-zerobias": "latest",
+        "@zerobias-org/compliance_feature-zerobias-f_aufsd": "latest",
+        "@zerobias-org/compliance_feature-zerobias-f_iw_cicd": "latest",
+        "@zerobias-org/compliance_feature-zerobias-f_iw_vcs": "latest",
+        "@zerobias-org/compliance_feature-zerobias-f_rp": "latest",
+        "@zerobias-org/compliance_feature-zerobias-f_rs": "latest",
+        "@zerobias-org/compliance_feature-zerobias-f_safsd": "latest",
+        "@zerobias-org/compliance_feature-zerobias-f_sbomg": "latest",
+        "@zerobias-org/compliance_feature-zerobias-f_slm2": "latest",
+        "@zerobias-org/compliance_feature-zerobias-f_vs": "latest",
         "@zerobias-org/segment_type-zerobias": "latest",
         "@zerobias-org/segment-zerobias-c_as": "latest"
       }
@@ -18,6 +27,87 @@
       "version": "1.0.0",
       "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
       "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "node_modules/@zerobias-org/compliance_feature-zerobias-f_aufsd": {
+      "version": "2.0.0",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/compliance_feature-zerobias-f_aufsd/-/compliance_feature-zerobias-f_aufsd-2.0.0.tgz",
+      "integrity": "sha512-UBHktxZvO70ngy5GoSwNMrwWFl0cKGV7rPl8UwrObtKWWfsQYZXIt+hDN/iDT8QzJ488U92j0bLw4dddesGegA==",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "latest"
+      }
+    },
+    "node_modules/@zerobias-org/compliance_feature-zerobias-f_iw_cicd": {
+      "version": "2.0.0",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/compliance_feature-zerobias-f_iw_cicd/-/compliance_feature-zerobias-f_iw_cicd-2.0.0.tgz",
+      "integrity": "sha512-2EZ2jvQ5qBV6xuMtFoUxBnvl/iRhlxDZJZKwLSyVk7wxEHoWvF+KNR75/faZHaWXwtlAK2enOTH7EFjnSOAFXA==",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "latest"
+      }
+    },
+    "node_modules/@zerobias-org/compliance_feature-zerobias-f_iw_vcs": {
+      "version": "2.0.0",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/compliance_feature-zerobias-f_iw_vcs/-/compliance_feature-zerobias-f_iw_vcs-2.0.0.tgz",
+      "integrity": "sha512-7zizElcmbrZkpdLYY7CGU7O2jYPyhXmf9zv+6EufBkv/u72Q3ABE8fBzIYJhkYSK4UcaypFx7lMdY+yDMMxBWA==",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "latest"
+      }
+    },
+    "node_modules/@zerobias-org/compliance_feature-zerobias-f_rp": {
+      "version": "2.0.0",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/compliance_feature-zerobias-f_rp/-/compliance_feature-zerobias-f_rp-2.0.0.tgz",
+      "integrity": "sha512-Z8ZWJOY2ngmGW8Tc+75K7f5Dd3oT2pdcHwCExmxWJmNFJCd4Xto/vDRLcUqtbNKPYYloqd5nq9NWptC8C9/6Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "latest"
+      }
+    },
+    "node_modules/@zerobias-org/compliance_feature-zerobias-f_rs": {
+      "version": "2.0.0",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/compliance_feature-zerobias-f_rs/-/compliance_feature-zerobias-f_rs-2.0.0.tgz",
+      "integrity": "sha512-d6hjuKViZmSSUwBKGNVIHHwv9wvbIJ8woYa7CV2VqgJTGyw+B+uMrJEKoPoanFqOYngIO2ChliTEMNoxUEMcfA==",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "latest"
+      }
+    },
+    "node_modules/@zerobias-org/compliance_feature-zerobias-f_safsd": {
+      "version": "2.0.1",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/compliance_feature-zerobias-f_safsd/-/compliance_feature-zerobias-f_safsd-2.0.1.tgz",
+      "integrity": "sha512-hSvEEgs9F1YxDJ5UN93o7YZIufVGd2nsHCPwr9F3XIiiwpg1ZH6/ecxiIyvu/TsSKui/bDRbWMkMdc8+BjA/7A==",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "latest"
+      }
+    },
+    "node_modules/@zerobias-org/compliance_feature-zerobias-f_sbomg": {
+      "version": "1.0.0-dev.0",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/compliance_feature-zerobias-f_sbomg/-/compliance_feature-zerobias-f_sbomg-1.0.0-dev.0.tgz",
+      "integrity": "sha512-YOwY1mBEZcSg0z6l7WYvjuNynPOCAMT2WHg7a2gfEfXdhrqjbp4a+czpB8TvFKlXXOccE5qVLrDUk/7506qHBA==",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "latest"
+      }
+    },
+    "node_modules/@zerobias-org/compliance_feature-zerobias-f_slm2": {
+      "version": "2.0.0",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/compliance_feature-zerobias-f_slm2/-/compliance_feature-zerobias-f_slm2-2.0.0.tgz",
+      "integrity": "sha512-9CvPPATOGgZ6TuXbmCMm1CHh5J8k2tEVcEUcwt9V4rav0Bw/KE+ObPndS8ftwGDNRLElkpCkvyLcozvkjeVbwQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "latest"
+      }
+    },
+    "node_modules/@zerobias-org/compliance_feature-zerobias-f_vs": {
+      "version": "2.0.1",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/compliance_feature-zerobias-f_vs/-/compliance_feature-zerobias-f_vs-2.0.1.tgz",
+      "integrity": "sha512-68tOKV+bAkik3A0wwu65F8zaZIwGKGJkuYYWe7KHr/mjvu90J8uE8csNGXDe1nA57W6SuNnAJdCBXc4SdpWIHg==",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "latest"
+      }
     },
     "node_modules/@zerobias-org/segment_type-zerobias": {
       "version": "1.0.14",
@@ -52,6 +142,78 @@
       "version": "1.0.0",
       "resolved": "https://pkg.zerobias.org/@auditlogic/vendor-zerobias/-/e051a99849948ce67721da0d5215aae8e293906e",
       "integrity": "sha512-+rgU3lJDY04mkQxk8jwKWtCTDVUIDxH5YitnJbp3gNecFqCIIaq6GUXH06ZMSi8pcivWMOuYilyXPYdVlmT2Gw=="
+    },
+    "@zerobias-org/compliance_feature-zerobias-f_aufsd": {
+      "version": "2.0.0",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/compliance_feature-zerobias-f_aufsd/-/compliance_feature-zerobias-f_aufsd-2.0.0.tgz",
+      "integrity": "sha512-UBHktxZvO70ngy5GoSwNMrwWFl0cKGV7rPl8UwrObtKWWfsQYZXIt+hDN/iDT8QzJ488U92j0bLw4dddesGegA==",
+      "requires": {
+        "@auditlogic/vendor-zerobias": "latest"
+      }
+    },
+    "@zerobias-org/compliance_feature-zerobias-f_iw_cicd": {
+      "version": "2.0.0",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/compliance_feature-zerobias-f_iw_cicd/-/compliance_feature-zerobias-f_iw_cicd-2.0.0.tgz",
+      "integrity": "sha512-2EZ2jvQ5qBV6xuMtFoUxBnvl/iRhlxDZJZKwLSyVk7wxEHoWvF+KNR75/faZHaWXwtlAK2enOTH7EFjnSOAFXA==",
+      "requires": {
+        "@auditlogic/vendor-zerobias": "latest"
+      }
+    },
+    "@zerobias-org/compliance_feature-zerobias-f_iw_vcs": {
+      "version": "2.0.0",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/compliance_feature-zerobias-f_iw_vcs/-/compliance_feature-zerobias-f_iw_vcs-2.0.0.tgz",
+      "integrity": "sha512-7zizElcmbrZkpdLYY7CGU7O2jYPyhXmf9zv+6EufBkv/u72Q3ABE8fBzIYJhkYSK4UcaypFx7lMdY+yDMMxBWA==",
+      "requires": {
+        "@auditlogic/vendor-zerobias": "latest"
+      }
+    },
+    "@zerobias-org/compliance_feature-zerobias-f_rp": {
+      "version": "2.0.0",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/compliance_feature-zerobias-f_rp/-/compliance_feature-zerobias-f_rp-2.0.0.tgz",
+      "integrity": "sha512-Z8ZWJOY2ngmGW8Tc+75K7f5Dd3oT2pdcHwCExmxWJmNFJCd4Xto/vDRLcUqtbNKPYYloqd5nq9NWptC8C9/6Yg==",
+      "requires": {
+        "@auditlogic/vendor-zerobias": "latest"
+      }
+    },
+    "@zerobias-org/compliance_feature-zerobias-f_rs": {
+      "version": "2.0.0",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/compliance_feature-zerobias-f_rs/-/compliance_feature-zerobias-f_rs-2.0.0.tgz",
+      "integrity": "sha512-d6hjuKViZmSSUwBKGNVIHHwv9wvbIJ8woYa7CV2VqgJTGyw+B+uMrJEKoPoanFqOYngIO2ChliTEMNoxUEMcfA==",
+      "requires": {
+        "@auditlogic/vendor-zerobias": "latest"
+      }
+    },
+    "@zerobias-org/compliance_feature-zerobias-f_safsd": {
+      "version": "2.0.1",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/compliance_feature-zerobias-f_safsd/-/compliance_feature-zerobias-f_safsd-2.0.1.tgz",
+      "integrity": "sha512-hSvEEgs9F1YxDJ5UN93o7YZIufVGd2nsHCPwr9F3XIiiwpg1ZH6/ecxiIyvu/TsSKui/bDRbWMkMdc8+BjA/7A==",
+      "requires": {
+        "@auditlogic/vendor-zerobias": "latest"
+      }
+    },
+    "@zerobias-org/compliance_feature-zerobias-f_sbomg": {
+      "version": "1.0.0-dev.0",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/compliance_feature-zerobias-f_sbomg/-/compliance_feature-zerobias-f_sbomg-1.0.0-dev.0.tgz",
+      "integrity": "sha512-YOwY1mBEZcSg0z6l7WYvjuNynPOCAMT2WHg7a2gfEfXdhrqjbp4a+czpB8TvFKlXXOccE5qVLrDUk/7506qHBA==",
+      "requires": {
+        "@auditlogic/vendor-zerobias": "latest"
+      }
+    },
+    "@zerobias-org/compliance_feature-zerobias-f_slm2": {
+      "version": "2.0.0",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/compliance_feature-zerobias-f_slm2/-/compliance_feature-zerobias-f_slm2-2.0.0.tgz",
+      "integrity": "sha512-9CvPPATOGgZ6TuXbmCMm1CHh5J8k2tEVcEUcwt9V4rav0Bw/KE+ObPndS8ftwGDNRLElkpCkvyLcozvkjeVbwQ==",
+      "requires": {
+        "@auditlogic/vendor-zerobias": "latest"
+      }
+    },
+    "@zerobias-org/compliance_feature-zerobias-f_vs": {
+      "version": "2.0.1",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/compliance_feature-zerobias-f_vs/-/compliance_feature-zerobias-f_vs-2.0.1.tgz",
+      "integrity": "sha512-68tOKV+bAkik3A0wwu65F8zaZIwGKGJkuYYWe7KHr/mjvu90J8uE8csNGXDe1nA57W6SuNnAJdCBXc4SdpWIHg==",
+      "requires": {
+        "@auditlogic/vendor-zerobias": "latest"
+      }
     },
     "@zerobias-org/segment_type-zerobias": {
       "version": "1.0.14",

--- a/package/zerobias/t_sca/package.json
+++ b/package/zerobias/t_sca/package.json
@@ -29,6 +29,15 @@
   },
   "dependencies": {
     "@auditlogic/vendor-zerobias": "latest",
+    "@zerobias-org/compliance_feature-zerobias-f_aufsd": "latest",
+    "@zerobias-org/compliance_feature-zerobias-f_iw_cicd": "latest",
+    "@zerobias-org/compliance_feature-zerobias-f_iw_vcs": "latest",
+    "@zerobias-org/compliance_feature-zerobias-f_rp": "latest",
+    "@zerobias-org/compliance_feature-zerobias-f_rs": "latest",
+    "@zerobias-org/compliance_feature-zerobias-f_safsd": "latest",
+    "@zerobias-org/compliance_feature-zerobias-f_sbomg": "latest",
+    "@zerobias-org/compliance_feature-zerobias-f_slm2": "latest",
+    "@zerobias-org/compliance_feature-zerobias-f_vs": "latest",
     "@zerobias-org/segment-zerobias-c_as": "latest",
     "@zerobias-org/segment_type-zerobias": "latest"
   }

--- a/package/zerobias/t_sca/supports.yml
+++ b/package/zerobias/t_sca/supports.yml
@@ -1,0 +1,28 @@
+supports:
+  - complianceFeature: f_aufsd
+    status: supported
+    strength: high
+  - complianceFeature: f_iw_cicd
+    status: supported
+    strength: medium
+  - complianceFeature: f_iw_vcs
+    status: supported
+    strength: high
+  - complianceFeature: f_rp
+    status: supported
+    strength: medium
+  - complianceFeature: f_rs
+    status: supported
+    strength: medium
+  - complianceFeature: f_safsd
+    status: supported
+    strength: high
+  - complianceFeature: f_sbomg
+    status: supported
+    strength: high
+  - complianceFeature: f_slm2
+    status: supported
+    strength: medium
+  - complianceFeature: f_vs
+    status: supported
+    strength: high

--- a/package/zerobias/t_vchp/gate-stamp.json
+++ b/package/zerobias/t_vchp/gate-stamp.json
@@ -1,7 +1,7 @@
 {
   "version": "2.0.0-uat.0",
-  "branch": "chore/bootstrap-gradle-zbb",
-  "sourceHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "branch": "feat/github-segment-features",
+  "sourceHash": "73c7bc398832263efcdfa4369e2032f8174078bed277802d82fcdc66b86d2a20",
   "testHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "tasks": {
     "validate": "passed",

--- a/package/zerobias/t_vchp/npm-shrinkwrap.json
+++ b/package/zerobias/t_vchp/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@zerobias-org/segment-zerobias-t_vchp",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@zerobias-org/segment-zerobias-t_vchp",
-      "version": "1.0.2",
+      "version": "2.0.0",
       "license": "ISC",
       "dependencies": {
         "@auditlogic/vendor-zerobias": "latest",
@@ -17,6 +17,7 @@
         "@zerobias-org/compliance_feature-zerobias-f_cbam": "latest",
         "@zerobias-org/compliance_feature-zerobias-f_ce2": "latest",
         "@zerobias-org/compliance_feature-zerobias-f_chfcr": "latest",
+        "@zerobias-org/compliance_feature-zerobias-f_crfcr": "latest",
         "@zerobias-org/compliance_feature-zerobias-f_cs2": "latest",
         "@zerobias-org/compliance_feature-zerobias-f_dfcr": "latest",
         "@zerobias-org/compliance_feature-zerobias-f_it": "latest",
@@ -99,6 +100,15 @@
       "version": "1.0.1",
       "resolved": "https://pkg.zerobias.org/@zerobias-org/compliance_feature-zerobias-f_chfcr/-/compliance_feature-zerobias-f_chfcr-1.0.1.tgz",
       "integrity": "sha512-yZbVbbKJh3VsuAv1RNkUvQ7bmIB/V3sU88asxHfFEJ5wPlT0RTBzQtiKfZ8+GBtXHCBlV1Zz5NC/yeZyANiVXQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@auditlogic/vendor-zerobias": "latest"
+      }
+    },
+    "node_modules/@zerobias-org/compliance_feature-zerobias-f_crfcr": {
+      "version": "1.0.0-dev.0",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/compliance_feature-zerobias-f_crfcr/-/compliance_feature-zerobias-f_crfcr-1.0.0-dev.0.tgz",
+      "integrity": "sha512-wzZH+0CDANAF559BOjh/k+wmlvfNWugpiJ9E4wHLfv8lL0GUfIdDIfFhoWGT7hiV/0CQX+6zrHCzqYPavImGaA==",
       "license": "ISC",
       "dependencies": {
         "@auditlogic/vendor-zerobias": "latest"
@@ -325,6 +335,14 @@
       "version": "1.0.1",
       "resolved": "https://pkg.zerobias.org/@zerobias-org/compliance_feature-zerobias-f_chfcr/-/compliance_feature-zerobias-f_chfcr-1.0.1.tgz",
       "integrity": "sha512-yZbVbbKJh3VsuAv1RNkUvQ7bmIB/V3sU88asxHfFEJ5wPlT0RTBzQtiKfZ8+GBtXHCBlV1Zz5NC/yeZyANiVXQ==",
+      "requires": {
+        "@auditlogic/vendor-zerobias": "latest"
+      }
+    },
+    "@zerobias-org/compliance_feature-zerobias-f_crfcr": {
+      "version": "1.0.0-dev.0",
+      "resolved": "https://pkg.zerobias.org/@zerobias-org/compliance_feature-zerobias-f_crfcr/-/compliance_feature-zerobias-f_crfcr-1.0.0-dev.0.tgz",
+      "integrity": "sha512-wzZH+0CDANAF559BOjh/k+wmlvfNWugpiJ9E4wHLfv8lL0GUfIdDIfFhoWGT7hiV/0CQX+6zrHCzqYPavImGaA==",
       "requires": {
         "@auditlogic/vendor-zerobias": "latest"
       }

--- a/package/zerobias/t_vchp/package.json
+++ b/package/zerobias/t_vchp/package.json
@@ -35,6 +35,7 @@
     "@zerobias-org/compliance_feature-zerobias-f_cbam": "latest",
     "@zerobias-org/compliance_feature-zerobias-f_ce2": "latest",
     "@zerobias-org/compliance_feature-zerobias-f_chfcr": "latest",
+    "@zerobias-org/compliance_feature-zerobias-f_crfcr": "latest",
     "@zerobias-org/compliance_feature-zerobias-f_cs2": "latest",
     "@zerobias-org/compliance_feature-zerobias-f_dfcr": "latest",
     "@zerobias-org/compliance_feature-zerobias-f_it": "latest",

--- a/package/zerobias/t_vchp/supports.yml
+++ b/package/zerobias/t_vchp/supports.yml
@@ -20,6 +20,9 @@ supports:
   - complianceFeature: f_chfcr
     status: supported
     strength: high
+  - complianceFeature: f_crfcr
+    status: supported
+    strength: high
   - complianceFeature: f_cs2
     status: supported
     strength: high


### PR DESCRIPTION
Final piece of the GitHub catalog completion: segment→feature wiring so the product's control chain resolves end-to-end (product → segments → features → SCF controls).

## Changes
- **c_vcs** (Version Control Systems): f_cvm2, f_cbam, f_vhad, f_rc — capabilities definitional to any VCS.
- **t_aica** (AI Coding Assistant): f_aipf, f_aicg, f_iw_des (high); f_iw_vcs, f_atg (medium).
- **t_sca** (Software Composition Analysis): f_safsd, f_aufsd, f_vs, f_iw_vcs, f_sbomg (high); f_slm2, f_rp, f_rs, f_iw_cicd (medium).
- **t_vchp**: +f_crfcr (Code Review) — the one PR-review capability its 22 entries lacked.
- package.json dependencies mirror the supports entries (repo convention); shrinkwraps regenerated against the published f_aicg/f_sbomg/f_crfcr@1.0.0-dev.0; gates green with post-commit stamps.

## ⚠️ SME review
- **Strength values use medium/low** where support is real but weaker — the existing pool uses only `high` (207/207 entries). Flatten to high if you prefer convention over signal.
- **d_sd (Software Development) deliberately NOT wired** — no domain-level segment carries supports today, and features there would flow to every dev product in the catalog.
- These supports flow to ALL products in these segments, not just GitHub (that's the point, but worth being aware of — e.g. every AI-coding-assistant product now inherits f_aicg).

🤖 Generated with [Claude Code](https://claude.com/claude-code)